### PR TITLE
feat(zod-to-proxy): lazy-validation Proxy wrapper for Zod schemas

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,5 +3,7 @@ dist
 /.changeset
 CHANGELOG.md
 LICENSE
+# Design documents (contain non-parseable code snippets)
+docs/plans/
 # Generated files
 mockServiceWorker.js

--- a/docs/plans/2026-06-11-zod-to-proxy-design.md
+++ b/docs/plans/2026-06-11-zod-to-proxy-design.md
@@ -180,6 +180,113 @@ This eliminates three high risks:
 
 Render-time throws from accessing invalid fields are accepted as inherent to the design — this is the whole point.
 
+## Zodios Integration: `resilientPlugin`
+
+### Problem
+
+Zodios's built-in `zodValidationPlugin` runs `schema.parse()` on every response. If any field fails validation — even one the UI never reads — the entire request throws `ZodiosError`. This is fatal in production when backend schemas evolve ahead of the frontend.
+
+### Three-Layer Defense Model
+
+```
+Layer 1: zodios response
+  │
+  ├─ parse succeeds → use parsed data (normal path)
+  │
+  └─ parse fails →
+      │
+      Layer 2: resilientPlugin
+      │  ├─ call onError(zodError, { method, path, data })  → report to Sentry/logging
+      │  └─ response.data = toProxy(schema, rawData)        → lazy-validation fallback
+      │
+      └─ UI accesses broken field →
+          │
+          Layer 3: ProxyZodError thrown at access site → React Error Boundary catches
+```
+
+- **Layer 1**: Zodios's normal parse. When it succeeds, data is fully validated and transformed — no laziness overhead.
+- **Layer 2**: On parse failure, `onError` fires for observability (Sentry, logging, metrics). The response falls back to `toProxy()`, which wraps raw data in a lazy-validating Proxy.
+- **Layer 3**: If the UI accesses a broken field, `ProxyZodError` is thrown at the exact access site. React Error Boundaries catch this per-component, so only the affected UI degrades — the rest of the page continues working.
+
+### API Surface
+
+```ts
+import { resilientPlugin } from "@crescendolab/zod-to-proxy/zodios";
+import type { ResilientPluginOptions } from "@crescendolab/zod-to-proxy/zodios";
+
+interface ResilientPluginOptions {
+  onError: (
+    error: ZodError,
+    context: { method: string; path: string; data: unknown },
+  ) => void;
+}
+
+function resilientPlugin(options: ResilientPluginOptions): ZodiosPlugin;
+```
+
+### Usage
+
+```ts
+import { Zodios } from "@zodios/core";
+import { resilientPlugin } from "@crescendolab/zod-to-proxy/zodios";
+
+const api = new Zodios(baseUrl, endpoints);
+
+api.use(
+  resilientPlugin({
+    onError: (error, { method, path, data }) => {
+      Sentry.captureException(error, {
+        tags: { endpoint: `${method} ${path}` },
+        extra: { responseData: data },
+      });
+    },
+  }),
+);
+
+// Normal usage — no API changes needed
+const user = await api.get("/users/:id", { params: { id: 1 } });
+// If response parse failed: user is a toProxy() wrapper
+// Accessing user.name works if name is valid in raw data
+// Accessing user.brokenField throws ProxyZodError → Error Boundary
+```
+
+### How It Works
+
+1. **Auto-replaces built-in validation**: The plugin uses `name: "zod-validation"` — zodios replaces any existing plugin with the same name. No need for users to manually disable the built-in `zodValidationPlugin`.
+
+2. **Request validation preserved**: Request validation is delegated to the original `zodValidationPlugin` (eager, strict). `toProxy` only applies to responses — request data is under the developer's control and should fail fast.
+
+3. **Response validation flow**:
+   - Find the matching endpoint definition from the API schema
+   - Skip non-JSON responses (passthrough)
+   - Run `endpoint.response.safeParseAsync(response.data)`
+   - Success → use parsed/transformed data (identical to built-in behavior)
+   - Failure → call `onError` + wrap raw data with `toProxy(schema, rawData)`
+
+4. **Content-type gating**: Only JSON responses (`application/json`, `application/vnd.api+json`) are validated. Binary, text, and other content types pass through unchanged.
+
+### Package Structure
+
+Exported as a subpath to keep `@zodios/core` as an optional peer dependency:
+
+```json
+{
+  "exports": {
+    ".": { "types": "./dist/index.d.ts", "default": "./dist/index.js" },
+    "./zodios": { "types": "./dist/zodios.d.ts", "default": "./dist/zodios.js" }
+  },
+  "peerDependencies": {
+    "@zodios/core": "^10.9.0",
+    "zod": "^3.25.51"
+  },
+  "peerDependenciesMeta": {
+    "@zodios/core": { "optional": true }
+  }
+}
+```
+
+Users who don't use zodios never pull in `@zodios/core` — the import path `@crescendolab/zod-to-proxy/zodios` simply won't be used, and tree-shaking eliminates the code.
+
 ## Non-Goals (v1)
 
 - **Mutation / two-way binding**: Proxies are read-only
@@ -208,6 +315,7 @@ Render-time throws from accessing invalid fields are accepted as inherent to the
 | `Object.prototype` pollution in shape lookup | Medium | `Object.hasOwn()` gating (verified on zod 3.25.51) |
 | `toJSON` trap bypass | Medium | Explicit special-case in get trap |
 | Frozen object Proxy invariants | Low | Degrade to atomic mode |
+| zodios plugin chain order change | Medium | Integration tests against `@zodios/core` ^10.9.0; name-based replacement is a documented API |
 
 ### Accepted (inherent)
 
@@ -218,7 +326,7 @@ Render-time throws from accessing invalid fields are accepted as inherent to the
 
 ## TDD Plan
 
-16 test clusters in implementation order:
+18 test clusters in implementation order:
 
 | # | Cluster | Focus |
 |---|---------|-------|
@@ -237,20 +345,24 @@ Render-time throws from accessing invalid fields are accepted as inherent to the
 | 13 | Error details | `ProxyZodError.path` correctness (nested), `.zodError` relative, `.flatIssues()`, `.isProxyZodError()` cross-realm |
 | 14 | Ecosystem pinning | Zod version lock test, schema internal structure assertions |
 | 15 | Type tests | `expectTypeOf` for `ReadonlyDeep`, `ProxyZodError` guard narrowing |
-| 16 | CI exhaustiveness | Integration test: real zodios response schema → selective access → no throw for valid paths |
+| 16 | Real-world patterns | Class transforms, tolerantEnum, discriminatedUnion, union+catch, array of mixed-validity items |
+| 17 | Zodios resilientPlugin | Plugin replaces built-in, request delegation, response fallback to toProxy, onError callback, content-type gating |
+| 18 | CI exhaustiveness | Integration test: real zodios response schema → selective access → no throw for valid paths |
 
 ## Package Structure
 
 ```
 packages/zod-to-proxy/
 ├── src/
-│   ├── index.ts           # public exports
+│   ├── index.ts           # public exports (toProxy, ProxyZodError, etc.)
 │   ├── to-proxy.ts        # toProxy implementation
 │   ├── proxy-zod-error.ts # ProxyZodError class
 │   ├── classify.ts        # schema node classification
 │   ├── traps.ts           # Proxy trap implementations
 │   ├── cache.ts           # WeakMap registry
-│   └── warnings.ts        # dev-mode warnings
+│   ├── warnings.ts        # dev-mode warnings
+│   ├── zodios.ts          # subpath export for zodios integration
+│   └── zodios-plugin.ts   # resilientPlugin implementation
 ├── tests/
 │   ├── root.test.ts
 │   ├── object.test.ts
@@ -267,6 +379,7 @@ packages/zod-to-proxy/
 │   ├── error.test.ts
 │   ├── ecosystem.test.ts
 │   ├── types.test.ts
+│   ├── real-world.test.ts
 │   └── integration.test.ts
 ├── package.json
 ├── tsconfig.json
@@ -276,6 +389,7 @@ packages/zod-to-proxy/
 ## Dependencies
 
 - `zod` (peer, `^3.25.51`)
+- `@zodios/core` (optional peer, `^10.9.0` — only needed for `resilientPlugin`)
 - `type-fest` (dependency, for `ReadonlyDeep`)
 - `vitest` (dev)
 - `tsdown` (dev, build)

--- a/docs/plans/2026-06-11-zod-to-proxy-design.md
+++ b/docs/plans/2026-06-11-zod-to-proxy-design.md
@@ -1,0 +1,282 @@
+# zod-to-proxy Design
+
+Lazy-validation Proxy wrapper for Zod schemas: validates only the fields you access.
+
+## Public API (v1)
+
+```ts
+import { toProxy, ProxyZodError, getRaw, materialize, isToProxy } from "@crescendolab/zod-to-proxy";
+
+// Core: wrap raw data with a lazy-validating Proxy
+toProxy<T extends z.ZodTypeAny>(schema: T, data: unknown): ReadonlyDeep<z.infer<T>>
+
+// Custom error thrown on access-time validation failure
+class ProxyZodError extends Error {
+  path: (string | number)[];   // absolute access path from root
+  zodError: ZodError;          // relative ZodError for the failing subtree
+  cause: ZodError;             // same as zodError (standard Error.cause)
+  flatIssues(): ZodIssue[];    // convenience: zodError.issues flattened
+  static isProxyZodError(e: unknown): e is ProxyZodError;
+  // Symbol.for("ProxyZodError") brand for cross-realm detection
+}
+
+// Escape hatches (lenient: non-proxy input returns input as-is)
+getRaw(proxy: unknown): unknown;         // extract original raw data
+materialize(proxy: unknown): unknown;    // full schema.parse() on the subtree
+isToProxy(value: unknown): boolean;      // detect proxy-wrapped values
+```
+
+Return type uses `ReadonlyDeep` from `type-fest` (not hand-rolled — naive `keyof` on function types yields `never`, breaking `Date`/`Map`/`Set` methods).
+
+## Schema Node Classification
+
+### Decomposable (lazy)
+
+Object access returns child proxies; children validate only when accessed.
+
+| Zod Type | Behavior |
+|----------|----------|
+| `ZodObject` | `shape` keys → lazy child proxies |
+| `ZodArray` | Index access → lazy child proxy per element |
+| `ZodTuple` | Index access → lazy child proxy per item schema |
+| `ZodOptional` | Unwrap `innerType`, propagate `undefined` |
+| `ZodNullable` | Unwrap `innerType`, propagate `null` |
+| `ZodDefault` | Unwrap `innerType`; substitute `defaultValue()` only for `undefined` (not `null`) |
+| `ZodReadonly` | Unwrap `innerType` (already read-only via Proxy) |
+| `ZodLazy` | Unwrap via `.schema` on first access |
+| `ZodPipeline` | Use `._def.out` as the effective schema |
+| `ZodBranded` | Unwrap `innerType` (brand is type-level only) |
+| `ZodCatch` | Unwrap `innerType`; on validation failure return `catchValue()` instead of throwing |
+
+### Atomic (eager on touch)
+
+Touching any property triggers `schema.parse(rawSubtree)` on the entire subtree.
+Untouched = not validated. This prevents partial observation of interdependent nodes.
+
+| Zod Type | Why atomic |
+|----------|-----------|
+| `ZodUnion` / `ZodDiscriminatedUnion` | Discriminant field must pick the right branch before children are valid |
+| `ZodIntersection` | Merged shape depends on validating both sides |
+| `ZodEffects` (refine/transform/preprocess) | User code may reshape data; partial access could observe pre-transform state |
+| `ZodRecord` | Keys are dynamic; shape is unknown until parse |
+
+### Leaf (terminal)
+
+Primitives, enums, literals, dates, etc. Returned as-is from raw data (validated by parent's lazy resolution).
+
+## Get Trap: 3-Tier Resolution
+
+For decomposable object/array nodes, property access follows this order:
+
+```
+1. Object.hasOwn(shape, key)  → resolve child schema, return lazy proxy
+2. Object.hasOwn(raw, key)    → return undefined (strip unknown keys)
+3. Reflect.get(target, key)   → prototype passthrough (toString, etc.)
+```
+
+### Special Cases
+
+- **`toJSON`**: Must be explicitly handled in the get trap (returns raw data). It doesn't match any of the 3 tiers: not in shape, not an own key of raw (usually), not on `Object.prototype`. Without special-casing, `JSON.stringify` falls through to `ownKeys` + full get traversal, causing full eager validation — defeating the purpose.
+- **`then`**: If `'then'` exists in the Zod shape, emit a dev-mode warning (thenable detection by Promise.resolve will trigger validation). Still lazy-resolve it.
+- **`Symbol.toPrimitive` / `Symbol.iterator`**: Passthrough via tier 3.
+- **`constructor`**: Must use `Object.hasOwn(shape, key)` (not `key in shape`) because `shape['constructor'] === Object` via prototype chain on zod 3.25.51.
+
+## Enumeration Traps
+
+| Trap | Behavior |
+|------|----------|
+| `ownKeys` | Returns `Reflect.ownKeys(shape)` for objects (schema-declared keys only) |
+| `has` | `key in proxy` → `Object.hasOwn(shape, key)` |
+| `getOwnPropertyDescriptor` | Synthetic descriptor for shape keys (enumerable, configurable, non-writable) |
+
+For arrays: `ownKeys` returns `['0', '1', ..., 'length']` based on raw array length.
+
+## Caching & Identity
+
+Global `WeakMap<ZodTypeAny, WeakMap<object, Proxy>>` registry ensures:
+- Same `(schema, rawObject)` pair → same proxy instance (referential stability)
+- Structural sharing: subtrees with the same schema node + same raw object reuse the same proxy
+- No memory leaks: WeakMap entries are GC'd when schema or raw data is collected
+
+Child proxies are cached per-parent on first access (lazy).
+
+## Read-Only Enforcement
+
+All mutation traps (`set`, `deleteProperty`, `defineProperty`) → `throw TypeError`.
+Return type is `ReadonlyDeep<z.infer<T>>` to enforce at the type level.
+
+## Frozen Input Handling
+
+If `!Object.isExtensible(raw)` (frozen/sealed), degrade to atomic mode: full `schema.parse(raw)` eagerly.
+Rationale: Proxy invariant constraints on frozen objects make lazy behavior unreliable. Degrading is safer than throwing.
+
+## Dev Warnings
+
+All gated behind `process.env.NODE_ENV !== 'production'`, warn-once per schema via `WeakSet`:
+
+1. **Atomic root**: `toProxy(z.union(...), data)` — entire tree validates on first access, no laziness benefit
+2. **`then` in shape**: Risk of thenable detection triggering unexpected validation
+3. **Frozen input degradation**: When falling back to atomic mode due to frozen data
+
+## Error Design
+
+```ts
+class ProxyZodError extends Error {
+  name = "ProxyZodError";
+  path: (string | number)[];
+  zodError: ZodError;
+  cause: ZodError;
+
+  constructor(path: (string | number)[], zodError: ZodError) {
+    super(`Validation failed at path: ${formatPath(path)}`);
+    this.path = path;
+    this.zodError = zodError;
+    this.cause = zodError;
+  }
+
+  flatIssues(): ZodIssue[] {
+    return this.zodError.issues;
+  }
+
+  static isProxyZodError(e: unknown): e is ProxyZodError {
+    return (
+      e instanceof ProxyZodError ||
+      (e != null && typeof e === "object" && Symbol.for("ProxyZodError") in e)
+    );
+  }
+
+  get [Symbol.for("ProxyZodError")]() {
+    return true;
+  }
+}
+```
+
+## React-Query Integration Architecture
+
+### Problem
+
+TanStack Query's structural sharing (`replaceEqualDeep`) deeply traverses cached data on every fetch. If the cache stores proxies, this triggers full validation — defeating laziness.
+
+### Solution: raw-in-cache + select wrapping
+
+```ts
+// In zodios hooks / user code:
+useQuery({
+  queryKey: [...],
+  queryFn: async () => {
+    const response = await zodiosClient.get(...);
+    return response; // raw data in cache
+  },
+  select: (raw) => toProxy(responseSchema, raw),
+  // structuralSharing on raw data (fast, no Proxy)
+  // toProxy called per-render but WeakMap cache ensures same proxy instance
+});
+```
+
+This eliminates three high risks:
+1. **Structural sharing**: operates on raw data, never touches proxies
+2. **Persistence/SSR**: serializes raw data, no Proxy in snapshot
+3. **Optimistic updates**: mutate raw data directly, no Proxy interaction
+
+Render-time throws from accessing invalid fields are accepted as inherent to the design — this is the whole point.
+
+## Non-Goals (v1)
+
+- **Mutation / two-way binding**: Proxies are read-only
+- **Async / streaming validation**: All validation is synchronous
+- **Schema inference from data**: Always requires explicit schema
+- **Partial parse / error recovery**: Access throws or succeeds, no middle ground (except `ZodCatch`)
+- **Custom error formatting**: `ProxyZodError` is the only error type
+- **Server-side rendering special handling**: Use raw data for SSR, wrap with `toProxy` on client
+
+## Risk Registry
+
+### Eliminated (architectural)
+
+| Risk | Mitigation |
+|------|-----------|
+| Structural sharing defeats laziness | raw-in-cache architecture; `toProxy` in `select` only |
+| Proxy in persistence/SSR | Raw data persisted; proxy is ephemeral |
+| Optimistic update on proxy | Mutations use raw data |
+
+### Mitigated
+
+| Risk | Severity | Mitigation |
+|------|----------|-----------|
+| Zod internal structure changes | High | Ecosystem pinning tests against specific zod versions |
+| Wrapper combination explosion | Medium | TDD matrix for optional × nullable × default combos |
+| `Object.prototype` pollution in shape lookup | Medium | `Object.hasOwn()` gating (verified on zod 3.25.51) |
+| `toJSON` trap bypass | Medium | Explicit special-case in get trap |
+| Frozen object Proxy invariants | Low | Degrade to atomic mode |
+
+### Accepted (inherent)
+
+| Risk | Why accepted |
+|------|-------------|
+| Render-time throws | Core design intent — invalid field access should throw |
+| Dev overhead of understanding lazy semantics | Dev warnings + documentation |
+
+## TDD Plan
+
+16 test clusters in implementation order:
+
+| # | Cluster | Focus |
+|---|---------|-------|
+| 1 | Root behavior | Primitive root throws, null/undefined root throws, object root returns proxy |
+| 2 | Object lazy access | Shape key → valid value, shape key → invalid value throws ProxyZodError, non-shape own key → undefined |
+| 3 | Wrapper semantics | optional(undefined), nullable(null), default substitution, nested wrappers, readonly unwrap |
+| 4 | Atomic nodes | Union touch → full parse, transform touch → full parse, refine touch → full parse, record touch → full parse |
+| 5 | Classification tightening | Verify each zod type maps to correct category (decomposable/atomic/leaf) |
+| 6 | Dev warnings | Atomic root warns, `then`-in-shape warns, frozen degradation warns, production mode suppresses |
+| 7 | Prototype & special keys | `toString`, `valueOf`, `constructor`, `Symbol.toPrimitive`, `Symbol.iterator` |
+| 8 | Enumeration traps | `Object.keys()`, `for...in`, `'key' in proxy`, spread operator |
+| 9 | Caching & identity | Same (schema, data) → same proxy, child proxy referential stability |
+| 10 | Read-only | `proxy.x = 1` throws TypeError, `delete proxy.x` throws TypeError |
+| 11 | Array behavior | Index access, `.length`, iteration, nested arrays, tuple semantics |
+| 12 | Escape hatches | `getRaw`, `materialize`, `isToProxy` — normal + non-proxy input |
+| 13 | Error details | `ProxyZodError.path` correctness (nested), `.zodError` relative, `.flatIssues()`, `.isProxyZodError()` cross-realm |
+| 14 | Ecosystem pinning | Zod version lock test, schema internal structure assertions |
+| 15 | Type tests | `expectTypeOf` for `ReadonlyDeep`, `ProxyZodError` guard narrowing |
+| 16 | CI exhaustiveness | Integration test: real zodios response schema → selective access → no throw for valid paths |
+
+## Package Structure
+
+```
+packages/zod-to-proxy/
+├── src/
+│   ├── index.ts           # public exports
+│   ├── to-proxy.ts        # toProxy implementation
+│   ├── proxy-zod-error.ts # ProxyZodError class
+│   ├── classify.ts        # schema node classification
+│   ├── traps.ts           # Proxy trap implementations
+│   ├── cache.ts           # WeakMap registry
+│   └── warnings.ts        # dev-mode warnings
+├── tests/
+│   ├── root.test.ts
+│   ├── object.test.ts
+│   ├── wrappers.test.ts
+│   ├── atomic.test.ts
+│   ├── classify.test.ts
+│   ├── warnings.test.ts
+│   ├── prototype.test.ts
+│   ├── enumeration.test.ts
+│   ├── cache.test.ts
+│   ├── readonly.test.ts
+│   ├── array.test.ts
+│   ├── escape-hatches.test.ts
+│   ├── error.test.ts
+│   ├── ecosystem.test.ts
+│   ├── types.test.ts
+│   └── integration.test.ts
+├── package.json
+├── tsconfig.json
+└── tsdown.config.ts
+```
+
+## Dependencies
+
+- `zod` (peer, `^3.25.51`)
+- `type-fest` (dependency, for `ReadonlyDeep`)
+- `vitest` (dev)
+- `tsdown` (dev, build)
+- `@changesets/cli` (dev, release)

--- a/packages/zod-to-proxy/LICENSE
+++ b/packages/zod-to-proxy/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2025-preset Crescendo Lab Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/zod-to-proxy/README.md
+++ b/packages/zod-to-proxy/README.md
@@ -1,0 +1,49 @@
+ <h1 align="center">@crescendolab/zodios-react-query-v5</h1>
+ <p align="center">
+   <a href="https://github.com/ecyrbe/zodios-react">
+     <img align="center" src="https://raw.githubusercontent.com/crescendolab-open/zodios-react-query-v5/main/docs/logo.svg" width="128px" alt="Zodios logo">
+   </a>
+ </p>
+ 
+ <p align="center">
+    React hooks for zodios backed by <a src="https://react-query.tanstack.com/" >react-query</a>
+ </p>
+ 
+ <p align="center">
+   <a href="https://www.npmjs.com/package/@crescendolab/zodios-react-query-v5">
+   <img src="https://img.shields.io/npm/v/@crescendolab/zodios-react-query-v5.svg" alt="langue typescript">
+   </a>
+   <a href="https://www.npmjs.com/package/@crescendolab/zodios-react-query-v5">
+   <img alt="npm" src="https://img.shields.io/npm/dw/@crescendolab/zodios-react-query-v5">
+   </a>
+   <a href="https://github.com/crescendolab-open/zodios-react-query-v5/blob/main/LICENSE">
+    <img alt="GitHub" src="https://img.shields.io/github/license/crescendolab-open/zodios-react-query-v5">   
+   </a>
+   <img alt="GitHub Workflow Status" src="https://img.shields.io/github/workflow/status/crescendolab-open/zodios-react-query-v5/CI">
+ </p>
+
+A [Crescendo Lab](https://cresclab.com/)–flavored fork of [ecyrbe/zodios-react](https://github.com/ecyrbe/zodios-react), updated to support React v19 and TanStack Query v5.
+
+# Install
+
+```bash
+> pnpm i @crescendolab/zodios-react-query-v5
+```
+
+# Usage
+
+Zodios comes with a Query and Mutation hook helper.  
+It's a thin wrapper around React-Query but with zodios auto completion.
+
+Zodios query hook also returns an invalidation helper to allow you to reset react query cache easily
+
+Check out [packages/examples](https://github.com/crescendolab-open/zodios-react-query-v5/tree/main/packages/examples) for
+a example.
+
+# License
+
+Forked from [ecyrbe/zodios-react](https://github.com/ecyrbe/zodios-react) which is licensed under the [MIT License](https://github.com/ecyrbe/zodios-react/blob/main/LICENSE)
+
+Copyright © 2025-preset Crescendo Lab Inc.
+
+Licensed under the [Apache License, Version 2.0](https://github.com/crescendolab-open/zodios-react-query-v5/blob/main/LICENSE)

--- a/packages/zod-to-proxy/package.json
+++ b/packages/zod-to-proxy/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@crescendolab/zod-to-proxy",
+  "version": "0.0.0",
+  "description": "Lazy-validation Proxy wrapper for Zod schemas",
+  "keywords": [
+    "zod",
+    "proxy",
+    "lazy",
+    "validation"
+  ],
+  "homepage": "https://github.com/crescendolab-open/zodios-react-query-v5",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/crescendolab-open/zodios-react-query-v5.git"
+  },
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "prepublishOnly": "pnpm run build"
+  },
+  "dependencies": {
+    "type-fest": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "zod": "catalog:"
+  },
+  "peerDependencies": {
+    "zod": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/zod-to-proxy/package.json
+++ b/packages/zod-to-proxy/package.json
@@ -15,6 +15,16 @@
   },
   "license": "Apache-2.0",
   "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./zodios": {
+      "types": "./dist/zodios.d.ts",
+      "default": "./dist/zodios.js"
+    }
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
@@ -34,7 +44,13 @@
     "zod": "catalog:"
   },
   "peerDependencies": {
+    "@zodios/core": "^10.9.0",
     "zod": "catalog:"
+  },
+  "peerDependenciesMeta": {
+    "@zodios/core": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "access": "public"

--- a/packages/zod-to-proxy/src/cache.ts
+++ b/packages/zod-to-proxy/src/cache.ts
@@ -1,0 +1,20 @@
+import type { ZodTypeAny } from "zod";
+
+const registry = new WeakMap<ZodTypeAny, WeakMap<object, object>>();
+
+export function getCached(schema: ZodTypeAny, raw: object): object | undefined {
+  return registry.get(schema)?.get(raw);
+}
+
+export function setCached(
+  schema: ZodTypeAny,
+  raw: object,
+  proxy: object,
+): void {
+  let inner = registry.get(schema);
+  if (!inner) {
+    inner = new WeakMap();
+    registry.set(schema, inner);
+  }
+  inner.set(raw, proxy);
+}

--- a/packages/zod-to-proxy/src/classify.ts
+++ b/packages/zod-to-proxy/src/classify.ts
@@ -1,0 +1,68 @@
+import type { ZodTypeAny } from "zod";
+import {
+  ZodArray,
+  ZodBranded,
+  ZodCatch,
+  ZodDefault,
+  ZodDiscriminatedUnion,
+  ZodEffects,
+  ZodIntersection,
+  ZodLazy,
+  ZodNullable,
+  ZodObject,
+  ZodOptional,
+  ZodPipeline,
+  ZodReadonly,
+  ZodRecord,
+  ZodTuple,
+  ZodUnion,
+} from "zod";
+
+export type NodeKind = "decomposable" | "atomic" | "leaf";
+
+export function classify(schema: ZodTypeAny): NodeKind {
+  if (
+    schema instanceof ZodObject ||
+    schema instanceof ZodArray ||
+    schema instanceof ZodTuple
+  ) {
+    return "decomposable";
+  }
+
+  if (
+    schema instanceof ZodOptional ||
+    schema instanceof ZodNullable ||
+    schema instanceof ZodDefault ||
+    schema instanceof ZodReadonly ||
+    schema instanceof ZodLazy ||
+    schema instanceof ZodBranded ||
+    schema instanceof ZodCatch ||
+    schema instanceof ZodPipeline
+  ) {
+    return "decomposable";
+  }
+
+  if (
+    schema instanceof ZodUnion ||
+    schema instanceof ZodDiscriminatedUnion ||
+    schema instanceof ZodIntersection ||
+    schema instanceof ZodEffects ||
+    schema instanceof ZodRecord
+  ) {
+    return "atomic";
+  }
+
+  return "leaf";
+}
+
+export function unwrap(schema: ZodTypeAny): ZodTypeAny | null {
+  if (schema instanceof ZodOptional) return schema.unwrap();
+  if (schema instanceof ZodNullable) return schema.unwrap();
+  if (schema instanceof ZodDefault) return schema._def.innerType as ZodTypeAny;
+  if (schema instanceof ZodReadonly) return schema._def.innerType as ZodTypeAny;
+  if (schema instanceof ZodBranded) return schema.unwrap();
+  if (schema instanceof ZodCatch) return schema._def.innerType as ZodTypeAny;
+  if (schema instanceof ZodLazy) return (schema as ZodLazy<ZodTypeAny>).schema;
+  if (schema instanceof ZodPipeline) return schema._def.out as ZodTypeAny;
+  return null;
+}

--- a/packages/zod-to-proxy/src/classify.ts
+++ b/packages/zod-to-proxy/src/classify.ts
@@ -36,8 +36,7 @@ export function classify(schema: ZodTypeAny): NodeKind {
     schema instanceof ZodReadonly ||
     schema instanceof ZodLazy ||
     schema instanceof ZodBranded ||
-    schema instanceof ZodCatch ||
-    schema instanceof ZodPipeline
+    schema instanceof ZodCatch
   ) {
     return "decomposable";
   }
@@ -47,7 +46,8 @@ export function classify(schema: ZodTypeAny): NodeKind {
     schema instanceof ZodDiscriminatedUnion ||
     schema instanceof ZodIntersection ||
     schema instanceof ZodEffects ||
-    schema instanceof ZodRecord
+    schema instanceof ZodRecord ||
+    schema instanceof ZodPipeline
   ) {
     return "atomic";
   }
@@ -63,6 +63,5 @@ export function unwrap(schema: ZodTypeAny): ZodTypeAny | null {
   if (schema instanceof ZodBranded) return schema.unwrap();
   if (schema instanceof ZodCatch) return schema._def.innerType as ZodTypeAny;
   if (schema instanceof ZodLazy) return (schema as ZodLazy<ZodTypeAny>).schema;
-  if (schema instanceof ZodPipeline) return schema._def.out as ZodTypeAny;
   return null;
 }

--- a/packages/zod-to-proxy/src/classify.ts
+++ b/packages/zod-to-proxy/src/classify.ts
@@ -1,67 +1,61 @@
 import type { ZodTypeAny } from "zod";
-import {
-  ZodArray,
-  ZodBranded,
-  ZodCatch,
-  ZodDefault,
-  ZodDiscriminatedUnion,
-  ZodEffects,
-  ZodIntersection,
-  ZodLazy,
-  ZodNullable,
-  ZodObject,
-  ZodOptional,
-  ZodPipeline,
-  ZodReadonly,
-  ZodRecord,
-  ZodTuple,
-  ZodUnion,
-} from "zod";
 
 export type NodeKind = "decomposable" | "atomic" | "leaf";
 
+interface ZodInternalDef {
+  typeName: string;
+  innerType?: ZodTypeAny;
+}
+
+function typeName(schema: ZodTypeAny): string {
+  return (schema._def as ZodInternalDef).typeName;
+}
+
+const DECOMPOSABLE_TYPES = new Set([
+  "ZodObject",
+  "ZodArray",
+  "ZodTuple",
+  "ZodOptional",
+  "ZodNullable",
+  "ZodDefault",
+  "ZodReadonly",
+  "ZodLazy",
+  "ZodBranded",
+  "ZodCatch",
+]);
+
+const ATOMIC_TYPES = new Set([
+  "ZodUnion",
+  "ZodDiscriminatedUnion",
+  "ZodIntersection",
+  "ZodEffects",
+  "ZodRecord",
+  "ZodPipeline",
+]);
+
 export function classify(schema: ZodTypeAny): NodeKind {
-  if (
-    schema instanceof ZodObject ||
-    schema instanceof ZodArray ||
-    schema instanceof ZodTuple
-  ) {
-    return "decomposable";
-  }
+  const name = typeName(schema);
 
-  if (
-    schema instanceof ZodOptional ||
-    schema instanceof ZodNullable ||
-    schema instanceof ZodDefault ||
-    schema instanceof ZodReadonly ||
-    schema instanceof ZodLazy ||
-    schema instanceof ZodBranded ||
-    schema instanceof ZodCatch
-  ) {
-    return "decomposable";
-  }
-
-  if (
-    schema instanceof ZodUnion ||
-    schema instanceof ZodDiscriminatedUnion ||
-    schema instanceof ZodIntersection ||
-    schema instanceof ZodEffects ||
-    schema instanceof ZodRecord ||
-    schema instanceof ZodPipeline
-  ) {
-    return "atomic";
-  }
+  if (DECOMPOSABLE_TYPES.has(name)) return "decomposable";
+  if (ATOMIC_TYPES.has(name)) return "atomic";
 
   return "leaf";
 }
 
 export function unwrap(schema: ZodTypeAny): ZodTypeAny | null {
-  if (schema instanceof ZodOptional) return schema.unwrap();
-  if (schema instanceof ZodNullable) return schema.unwrap();
-  if (schema instanceof ZodDefault) return schema._def.innerType as ZodTypeAny;
-  if (schema instanceof ZodReadonly) return schema._def.innerType as ZodTypeAny;
-  if (schema instanceof ZodBranded) return schema.unwrap();
-  if (schema instanceof ZodCatch) return schema._def.innerType as ZodTypeAny;
-  if (schema instanceof ZodLazy) return (schema as ZodLazy<ZodTypeAny>).schema;
+  const name = typeName(schema);
+
+  if (name === "ZodOptional" || name === "ZodNullable") {
+    return (schema as unknown as { unwrap: () => ZodTypeAny }).unwrap();
+  }
+  if (name === "ZodDefault" || name === "ZodReadonly" || name === "ZodCatch") {
+    return (schema._def as ZodInternalDef).innerType ?? null;
+  }
+  if (name === "ZodBranded") {
+    return (schema as unknown as { unwrap: () => ZodTypeAny }).unwrap();
+  }
+  if (name === "ZodLazy") {
+    return (schema as unknown as { schema: ZodTypeAny }).schema;
+  }
   return null;
 }

--- a/packages/zod-to-proxy/src/get-raw.ts
+++ b/packages/zod-to-proxy/src/get-raw.ts
@@ -1,0 +1,9 @@
+import { RAW_DATA } from "./symbols.js";
+
+export function getRaw(proxy: unknown): unknown {
+  if (proxy === null || proxy === undefined || typeof proxy !== "object") {
+    return proxy;
+  }
+  const raw = (proxy as Record<symbol, unknown>)[RAW_DATA];
+  return raw !== undefined ? raw : proxy;
+}

--- a/packages/zod-to-proxy/src/index.ts
+++ b/packages/zod-to-proxy/src/index.ts
@@ -1,0 +1,5 @@
+export { getRaw } from "./get-raw.js";
+export { isToProxy } from "./is-to-proxy.js";
+export { materialize } from "./materialize.js";
+export { ProxyZodError } from "./proxy-zod-error.js";
+export { toProxy } from "./to-proxy.js";

--- a/packages/zod-to-proxy/src/is-to-proxy.ts
+++ b/packages/zod-to-proxy/src/is-to-proxy.ts
@@ -1,0 +1,8 @@
+import { TO_PROXY_BRAND } from "./symbols.js";
+
+export function isToProxy(value: unknown): boolean {
+  if (value === null || value === undefined || typeof value !== "object") {
+    return false;
+  }
+  return TO_PROXY_BRAND in value;
+}

--- a/packages/zod-to-proxy/src/materialize.ts
+++ b/packages/zod-to-proxy/src/materialize.ts
@@ -1,0 +1,17 @@
+import type { ZodTypeAny } from "zod";
+
+import { RAW_DATA, SCHEMA } from "./symbols.js";
+
+export function materialize(proxy: unknown): unknown {
+  if (proxy === null || proxy === undefined || typeof proxy !== "object") {
+    return proxy;
+  }
+  const raw = (proxy as Record<symbol, unknown>)[RAW_DATA];
+  const schema = (proxy as Record<symbol, unknown>)[SCHEMA] as
+    | ZodTypeAny
+    | undefined;
+  if (raw !== undefined && schema) {
+    return schema.parse(raw);
+  }
+  return proxy;
+}

--- a/packages/zod-to-proxy/src/proxy-zod-error.ts
+++ b/packages/zod-to-proxy/src/proxy-zod-error.ts
@@ -1,0 +1,43 @@
+import type { ZodError, ZodIssue } from "zod";
+
+const BRAND = Symbol.for("ProxyZodError");
+
+function formatPath(path: Array<string | number>): string {
+  return path
+    .map((segment) =>
+      typeof segment === "number" ? `[${segment}]` : `.${segment}`,
+    )
+    .join("")
+    .replace(/^\./, "");
+}
+
+export class ProxyZodError extends Error {
+  override name = "ProxyZodError";
+  path: Array<string | number>;
+  zodError: ZodError;
+  override cause: ZodError;
+
+  constructor(path: Array<string | number>, zodError: ZodError) {
+    super(`Validation failed at path: ${formatPath(path)}`);
+    this.path = path;
+    this.zodError = zodError;
+    this.cause = zodError;
+  }
+
+  flatIssues(): Array<ZodIssue> {
+    return this.zodError.issues;
+  }
+
+  static isProxyZodError(e: unknown): e is ProxyZodError {
+    return (
+      e instanceof ProxyZodError ||
+      (e != null &&
+        typeof e === "object" &&
+        BRAND in (e as Record<symbol, unknown>))
+    );
+  }
+
+  get [BRAND]() {
+    return true;
+  }
+}

--- a/packages/zod-to-proxy/src/proxy-zod-error.ts
+++ b/packages/zod-to-proxy/src/proxy-zod-error.ts
@@ -3,6 +3,7 @@ import type { ZodError, ZodIssue } from "zod";
 const BRAND = Symbol.for("ProxyZodError");
 
 function formatPath(path: Array<string | number>): string {
+  if (path.length === 0) return "<root>";
   return path
     .map((segment) =>
       typeof segment === "number" ? `[${segment}]` : `.${segment}`,

--- a/packages/zod-to-proxy/src/symbols.ts
+++ b/packages/zod-to-proxy/src/symbols.ts
@@ -1,0 +1,3 @@
+export const TO_PROXY_BRAND = Symbol.for("toProxy");
+export const RAW_DATA = Symbol.for("toProxy.raw");
+export const SCHEMA = Symbol.for("toProxy.schema");

--- a/packages/zod-to-proxy/src/to-proxy.ts
+++ b/packages/zod-to-proxy/src/to-proxy.ts
@@ -9,6 +9,7 @@ import {
   ZodObject,
   ZodOptional,
   ZodTuple,
+  ZodUnknown,
 } from "zod";
 
 import { getCached, setCached } from "./cache.js";
@@ -97,19 +98,19 @@ function createObjectProxy(
   });
 }
 
-function createArrayProxy(
-  schema: ZodArray<ZodTypeAny>,
+function createIndexedProxy(
+  schema: ZodTypeAny,
   raw: Array<unknown>,
   path: Array<string | number>,
+  getItemSchema: (index: number) => ZodTypeAny,
 ): object {
   const childCache = new Map<number, unknown>();
-  const itemSchema = schema._def.type;
 
   function resolveIndex(index: number): unknown {
     if (childCache.has(index)) return childCache.get(index);
     const childRaw = raw[index];
     const childPath = [...path, index];
-    const resolved = resolveNode(itemSchema, childRaw, childPath);
+    const resolved = resolveNode(getItemSchema(index), childRaw, childPath);
     childCache.set(index, resolved);
     return resolved;
   }
@@ -208,11 +209,15 @@ function resolveNode(
   if (schema instanceof ZodCatch) {
     try {
       return resolveNode(schema._def.innerType as ZodTypeAny, raw, path);
-    } catch {
-      return schema._def.catchValue({
-        error: new ZodError([]),
-        input: raw,
-      });
+    } catch (err) {
+      if (err instanceof ProxyZodError || err instanceof ZodError) {
+        return schema._def.catchValue({
+          error:
+            err instanceof ProxyZodError ? err.zodError : (err as ZodError),
+          input: raw,
+        });
+      }
+      throw err;
     }
   }
 
@@ -277,13 +282,21 @@ function wrapDecomposable(
       path,
     );
   } else if (schema instanceof ZodArray) {
-    proxy = createArrayProxy(schema, raw as Array<unknown>, path);
-  } else if (schema instanceof ZodTuple) {
-    proxy = createArrayProxy(
-      // Treat tuple similarly to array for now — per-index schema handled later
-      schema as unknown as ZodArray<ZodTypeAny>,
+    const itemSchema = schema._def.type;
+    proxy = createIndexedProxy(
+      schema,
       raw as Array<unknown>,
       path,
+      () => itemSchema,
+    );
+  } else if (schema instanceof ZodTuple) {
+    const items = schema._def.items as Array<ZodTypeAny>;
+    const restSchema = schema._def.rest as ZodTypeAny | null;
+    proxy = createIndexedProxy(
+      schema,
+      raw as Array<unknown>,
+      path,
+      (index) => items[index] ?? restSchema ?? ZodUnknown.create(),
     );
   } else {
     throw new TypeError(

--- a/packages/zod-to-proxy/src/to-proxy.ts
+++ b/packages/zod-to-proxy/src/to-proxy.ts
@@ -93,9 +93,9 @@ function createObjectProxy(
     },
 
     getOwnPropertyDescriptor(target, key) {
-      if (typeof key === "symbol") return undefined;
       const targetDesc = Object.getOwnPropertyDescriptor(target, key);
       if (targetDesc && !targetDesc.configurable) return targetDesc;
+      if (typeof key === "symbol") return undefined;
       if (Object.hasOwn(shape, key)) {
         return {
           configurable: true,

--- a/packages/zod-to-proxy/src/to-proxy.ts
+++ b/packages/zod-to-proxy/src/to-proxy.ts
@@ -1,16 +1,6 @@
 import type { ReadonlyDeep } from "type-fest";
 import type { z, ZodTypeAny } from "zod";
-import {
-  ZodArray,
-  ZodCatch,
-  ZodDefault,
-  ZodError,
-  ZodNullable,
-  ZodObject,
-  ZodOptional,
-  ZodTuple,
-  ZodUnknown,
-} from "zod";
+import { ZodError, ZodUnknown } from "zod";
 
 import { getCached, setCached } from "./cache.js";
 import { classify, unwrap } from "./classify.js";
@@ -22,13 +12,28 @@ import {
   warnThenInShape,
 } from "./warnings.js";
 
+interface ZodInternalDef {
+  typeName: string;
+  innerType?: ZodTypeAny;
+  defaultValue?: () => unknown;
+  catchValue?: (ctx: { error: ZodError; input: unknown }) => unknown;
+  type?: ZodTypeAny;
+  items?: Array<ZodTypeAny>;
+  rest?: ZodTypeAny | null;
+}
+
+function typeName(schema: ZodTypeAny): string {
+  return (schema._def as ZodInternalDef).typeName;
+}
+
 function createObjectProxy(
-  schema: ZodObject<Record<string, ZodTypeAny>>,
+  schema: ZodTypeAny,
   raw: Record<string, unknown>,
   path: Array<string | number>,
 ): object {
   const childCache = new Map<string | symbol, unknown>();
-  const shape = schema.shape as Record<string, ZodTypeAny>;
+  const shape = (schema as unknown as { shape: Record<string, ZodTypeAny> })
+    .shape;
 
   if (Object.hasOwn(shape, "then")) {
     warnThenInShape(schema);
@@ -213,33 +218,41 @@ function resolveNode(
   raw: unknown,
   path: Array<string | number>,
 ): unknown {
-  if (schema instanceof ZodOptional) {
+  const name = typeName(schema);
+
+  if (name === "ZodOptional") {
     if (raw === undefined) return undefined;
-    return resolveNode(schema.unwrap(), raw, path);
+    return resolveNode(
+      (schema as unknown as { unwrap: () => ZodTypeAny }).unwrap(),
+      raw,
+      path,
+    );
   }
 
-  if (schema instanceof ZodNullable) {
+  if (name === "ZodNullable") {
     if (raw === null) return null;
-    return resolveNode(schema.unwrap(), raw, path);
+    return resolveNode(
+      (schema as unknown as { unwrap: () => ZodTypeAny }).unwrap(),
+      raw,
+      path,
+    );
   }
 
-  if (schema instanceof ZodDefault) {
+  if (name === "ZodDefault") {
+    const def = schema._def as ZodInternalDef;
     if (raw === undefined) {
-      return resolveNode(
-        schema._def.innerType as ZodTypeAny,
-        schema._def.defaultValue(),
-        path,
-      );
+      return resolveNode(def.innerType!, def.defaultValue!(), path);
     }
-    return resolveNode(schema._def.innerType as ZodTypeAny, raw, path);
+    return resolveNode(def.innerType!, raw, path);
   }
 
-  if (schema instanceof ZodCatch) {
+  if (name === "ZodCatch") {
+    const def = schema._def as ZodInternalDef;
     try {
-      return resolveNode(schema._def.innerType as ZodTypeAny, raw, path);
+      return resolveNode(def.innerType!, raw, path);
     } catch (err) {
       if (err instanceof ProxyZodError || err instanceof ZodError) {
-        return schema._def.catchValue({
+        return def.catchValue!({
           error:
             err instanceof ProxyZodError ? err.zodError : (err as ZodError),
           input: raw,
@@ -260,7 +273,7 @@ function resolveNode(
     try {
       return schema.parse(raw);
     } catch (err) {
-      throw new ProxyZodError(path, err as import("zod").ZodError);
+      throw new ProxyZodError(path, err as ZodError);
     }
   }
 
@@ -269,7 +282,7 @@ function resolveNode(
       schema.parse(raw);
       return raw;
     } catch (err) {
-      throw new ProxyZodError(path, err as import("zod").ZodError);
+      throw new ProxyZodError(path, err as ZodError);
     }
   }
 
@@ -278,7 +291,7 @@ function resolveNode(
       schema.parse(raw);
       return raw;
     } catch (err) {
-      throw new ProxyZodError(path, err as import("zod").ZodError);
+      throw new ProxyZodError(path, err as ZodError);
     }
   }
 
@@ -287,7 +300,7 @@ function resolveNode(
     try {
       return schema.parse(raw);
     } catch (err) {
-      throw new ProxyZodError(path, err as import("zod").ZodError);
+      throw new ProxyZodError(path, err as ZodError);
     }
   }
 
@@ -303,24 +316,22 @@ function wrapDecomposable(
   if (cached) return cached;
 
   let proxy: object;
+  const name = typeName(schema);
+  const def = schema._def as ZodInternalDef;
 
-  if (schema instanceof ZodObject) {
-    proxy = createObjectProxy(
-      schema as ZodObject<Record<string, ZodTypeAny>>,
-      raw as Record<string, unknown>,
-      path,
-    );
-  } else if (schema instanceof ZodArray) {
-    const itemSchema = schema._def.type;
+  if (name === "ZodObject") {
+    proxy = createObjectProxy(schema, raw as Record<string, unknown>, path);
+  } else if (name === "ZodArray") {
+    const itemSchema = def.type!;
     proxy = createIndexedProxy(
       schema,
       raw as Array<unknown>,
       path,
       () => itemSchema,
     );
-  } else if (schema instanceof ZodTuple) {
-    const items = schema._def.items as Array<ZodTypeAny>;
-    const restSchema = schema._def.rest as ZodTypeAny | null;
+  } else if (name === "ZodTuple") {
+    const items = def.items!;
+    const restSchema = def.rest ?? null;
     proxy = createIndexedProxy(
       schema,
       raw as Array<unknown>,

--- a/packages/zod-to-proxy/src/to-proxy.ts
+++ b/packages/zod-to-proxy/src/to-proxy.ts
@@ -83,13 +83,19 @@ function createObjectProxy(
       return [...keys];
     },
 
-    has(_target, key) {
-      if (typeof key === "symbol") return key === TO_PROXY_BRAND;
-      return Object.hasOwn(shape, key);
+    has(target, key) {
+      if (key === TO_PROXY_BRAND) return true;
+      if (typeof key === "symbol") return Reflect.has(target, key);
+      if (Object.hasOwn(shape, key)) return true;
+      const desc = Object.getOwnPropertyDescriptor(target, key);
+      if (desc && !desc.configurable) return true;
+      return false;
     },
 
     getOwnPropertyDescriptor(target, key) {
       if (typeof key === "symbol") return undefined;
+      const targetDesc = Object.getOwnPropertyDescriptor(target, key);
+      if (targetDesc && !targetDesc.configurable) return targetDesc;
       if (Object.hasOwn(shape, key)) {
         return {
           configurable: true,
@@ -98,8 +104,6 @@ function createObjectProxy(
           value: resolveKey(key as string),
         };
       }
-      const targetDesc = Object.getOwnPropertyDescriptor(target, key);
-      if (targetDesc && !targetDesc.configurable) return targetDesc;
       return undefined;
     },
   });
@@ -172,17 +176,22 @@ function createIndexedProxy(
       return [...keys];
     },
 
-    has(_target, key) {
+    has(target, key) {
       if (key === TO_PROXY_BRAND) return true;
-      if (typeof key === "symbol") return false;
+      if (typeof key === "symbol") return Reflect.has(target, key);
       if (key === "length") return true;
-      return isArrayIndex(key) && Number(key) < raw.length;
+      if (isArrayIndex(key) && Number(key) < raw.length) return true;
+      const desc = Object.getOwnPropertyDescriptor(target, key);
+      if (desc && !desc.configurable) return true;
+      return false;
     },
 
     getOwnPropertyDescriptor(target, key) {
       if (key === "length") {
         return Object.getOwnPropertyDescriptor(target, "length");
       }
+      const targetDesc = Object.getOwnPropertyDescriptor(target, key);
+      if (targetDesc && !targetDesc.configurable) return targetDesc;
       if (typeof key === "string" && isArrayIndex(key)) {
         const index = Number(key);
         if (index < raw.length) {
@@ -194,8 +203,6 @@ function createIndexedProxy(
           };
         }
       }
-      const targetDesc = Object.getOwnPropertyDescriptor(target, key);
-      if (targetDesc && !targetDesc.configurable) return targetDesc;
       return undefined;
     },
   });
@@ -270,6 +277,15 @@ function resolveNode(
     try {
       schema.parse(raw);
       return raw;
+    } catch (err) {
+      throw new ProxyZodError(path, err as import("zod").ZodError);
+    }
+  }
+
+  if (!Object.isExtensible(raw)) {
+    warnFrozenDegradation(schema);
+    try {
+      return schema.parse(raw);
     } catch (err) {
       throw new ProxyZodError(path, err as import("zod").ZodError);
     }

--- a/packages/zod-to-proxy/src/to-proxy.ts
+++ b/packages/zod-to-proxy/src/to-proxy.ts
@@ -74,8 +74,13 @@ function createObjectProxy(
       throw new TypeError("toProxy objects are read-only");
     },
 
-    ownKeys() {
-      return Reflect.ownKeys(shape);
+    ownKeys(target) {
+      const keys = new Set<string | symbol>(Reflect.ownKeys(shape));
+      for (const k of Reflect.ownKeys(target)) {
+        const desc = Object.getOwnPropertyDescriptor(target, k);
+        if (desc && !desc.configurable) keys.add(k);
+      }
+      return [...keys];
     },
 
     has(_target, key) {
@@ -83,7 +88,7 @@ function createObjectProxy(
       return Object.hasOwn(shape, key);
     },
 
-    getOwnPropertyDescriptor(_target, key) {
+    getOwnPropertyDescriptor(target, key) {
       if (typeof key === "symbol") return undefined;
       if (Object.hasOwn(shape, key)) {
         return {
@@ -93,9 +98,17 @@ function createObjectProxy(
           value: resolveKey(key as string),
         };
       }
+      const targetDesc = Object.getOwnPropertyDescriptor(target, key);
+      if (targetDesc && !targetDesc.configurable) return targetDesc;
       return undefined;
     },
   });
+}
+
+const ARRAY_INDEX_RE = /^(?:0|[1-9]\d*)$/;
+
+function isArrayIndex(key: string): boolean {
+  return ARRAY_INDEX_RE.test(key);
 }
 
 function createIndexedProxy(
@@ -125,9 +138,9 @@ function createIndexedProxy(
 
       if (typeof key === "symbol") return Reflect.get(target, key, receiver);
 
-      const index = Number(key);
-      if (Number.isInteger(index) && index >= 0 && index < raw.length) {
-        return resolveIndex(index);
+      if (isArrayIndex(key)) {
+        const index = Number(key);
+        if (index < raw.length) return resolveIndex(index);
       }
 
       return Reflect.get(target, key, receiver);
@@ -145,36 +158,44 @@ function createIndexedProxy(
       throw new TypeError("toProxy objects are read-only");
     },
 
-    ownKeys() {
-      const keys: Array<string> = [];
+    ownKeys(target) {
+      const keys = new Set<string>();
       for (let i = 0; i < raw.length; i++) {
-        keys.push(String(i));
+        keys.add(String(i));
       }
-      keys.push("length");
-      return keys;
+      keys.add("length");
+      for (const k of Reflect.ownKeys(target)) {
+        if (typeof k === "symbol") continue;
+        const desc = Object.getOwnPropertyDescriptor(target, k);
+        if (desc && !desc.configurable) keys.add(k);
+      }
+      return [...keys];
     },
 
     has(_target, key) {
       if (key === TO_PROXY_BRAND) return true;
       if (typeof key === "symbol") return false;
       if (key === "length") return true;
-      const index = Number(key);
-      return Number.isInteger(index) && index >= 0 && index < raw.length;
+      return isArrayIndex(key) && Number(key) < raw.length;
     },
 
     getOwnPropertyDescriptor(target, key) {
       if (key === "length") {
         return Object.getOwnPropertyDescriptor(target, "length");
       }
-      const index = Number(key);
-      if (Number.isInteger(index) && index >= 0 && index < raw.length) {
-        return {
-          configurable: true,
-          enumerable: true,
-          writable: false,
-          value: resolveIndex(index),
-        };
+      if (typeof key === "string" && isArrayIndex(key)) {
+        const index = Number(key);
+        if (index < raw.length) {
+          return {
+            configurable: true,
+            enumerable: true,
+            writable: false,
+            value: resolveIndex(index),
+          };
+        }
       }
+      const targetDesc = Object.getOwnPropertyDescriptor(target, key);
+      if (targetDesc && !targetDesc.configurable) return targetDesc;
       return undefined;
     },
   });
@@ -228,15 +249,7 @@ function resolveNode(
 
   const kind = classify(schema);
 
-  if (kind === "leaf") {
-    try {
-      return schema.parse(raw);
-    } catch (err) {
-      throw new ProxyZodError(path, err as import("zod").ZodError);
-    }
-  }
-
-  if (kind === "atomic") {
+  if (kind === "leaf" || kind === "atomic") {
     try {
       return schema.parse(raw);
     } catch (err) {

--- a/packages/zod-to-proxy/src/to-proxy.ts
+++ b/packages/zod-to-proxy/src/to-proxy.ts
@@ -15,6 +15,11 @@ import { getCached, setCached } from "./cache.js";
 import { classify, unwrap } from "./classify.js";
 import { ProxyZodError } from "./proxy-zod-error.js";
 import { RAW_DATA, SCHEMA, TO_PROXY_BRAND } from "./symbols.js";
+import {
+  warnAtomicRoot,
+  warnFrozenDegradation,
+  warnThenInShape,
+} from "./warnings.js";
 
 function createObjectProxy(
   schema: ZodObject<Record<string, ZodTypeAny>>,
@@ -23,6 +28,10 @@ function createObjectProxy(
 ): object {
   const childCache = new Map<string | symbol, unknown>();
   const shape = schema.shape as Record<string, ZodTypeAny>;
+
+  if (Object.hasOwn(shape, "then")) {
+    warnThenInShape(schema);
+  }
 
   function resolveKey(key: string): unknown {
     if (childCache.has(key)) return childCache.get(key);
@@ -309,8 +318,23 @@ export function toProxy<T extends ZodTypeAny>(
     inner = unwrap(effectiveSchema);
   }
 
+  const effectiveKind = classify(effectiveSchema);
+
   if (!Object.isExtensible(data)) {
+    warnFrozenDegradation(schema);
     return schema.parse(data) as ReadonlyDeep<z.infer<T>>;
+  }
+
+  if (effectiveKind === "atomic") {
+    warnAtomicRoot(schema);
+  }
+
+  if (effectiveKind !== "decomposable") {
+    try {
+      return schema.parse(data) as ReadonlyDeep<z.infer<T>>;
+    } catch (err) {
+      throw new ProxyZodError([], err as ZodError);
+    }
   }
 
   return wrapDecomposable(effectiveSchema, data as object, []) as ReadonlyDeep<

--- a/packages/zod-to-proxy/src/to-proxy.ts
+++ b/packages/zod-to-proxy/src/to-proxy.ts
@@ -1,0 +1,319 @@
+import type { ReadonlyDeep } from "type-fest";
+import type { z, ZodTypeAny } from "zod";
+import {
+  ZodArray,
+  ZodCatch,
+  ZodDefault,
+  ZodError,
+  ZodNullable,
+  ZodObject,
+  ZodOptional,
+  ZodTuple,
+} from "zod";
+
+import { getCached, setCached } from "./cache.js";
+import { classify, unwrap } from "./classify.js";
+import { ProxyZodError } from "./proxy-zod-error.js";
+import { RAW_DATA, SCHEMA, TO_PROXY_BRAND } from "./symbols.js";
+
+function createObjectProxy(
+  schema: ZodObject<Record<string, ZodTypeAny>>,
+  raw: Record<string, unknown>,
+  path: Array<string | number>,
+): object {
+  const childCache = new Map<string | symbol, unknown>();
+  const shape = schema.shape as Record<string, ZodTypeAny>;
+
+  function resolveKey(key: string): unknown {
+    if (childCache.has(key)) return childCache.get(key);
+    if (Object.hasOwn(shape, key)) {
+      const childSchema = shape[key]!;
+      const childRaw = raw[key];
+      const childPath = [...path, key];
+      const resolved = resolveNode(childSchema, childRaw, childPath);
+      childCache.set(key, resolved);
+      return resolved;
+    }
+    return undefined;
+  }
+
+  return new Proxy(raw, {
+    get(target, key, receiver) {
+      if (key === TO_PROXY_BRAND) return true;
+      if (key === RAW_DATA) return raw;
+      if (key === SCHEMA) return schema;
+      if (key === "toJSON") return () => raw;
+
+      if (typeof key === "symbol") return Reflect.get(target, key, receiver);
+
+      if (Object.hasOwn(shape, key)) return resolveKey(key);
+      if (Object.hasOwn(raw, key)) return undefined;
+
+      return Reflect.get(target, key, receiver);
+    },
+
+    set() {
+      throw new TypeError("toProxy objects are read-only");
+    },
+
+    deleteProperty() {
+      throw new TypeError("toProxy objects are read-only");
+    },
+
+    defineProperty() {
+      throw new TypeError("toProxy objects are read-only");
+    },
+
+    ownKeys() {
+      return Reflect.ownKeys(shape);
+    },
+
+    has(_target, key) {
+      if (typeof key === "symbol") return key === TO_PROXY_BRAND;
+      return Object.hasOwn(shape, key);
+    },
+
+    getOwnPropertyDescriptor(_target, key) {
+      if (typeof key === "symbol") return undefined;
+      if (Object.hasOwn(shape, key)) {
+        return {
+          configurable: true,
+          enumerable: true,
+          writable: false,
+          value: resolveKey(key as string),
+        };
+      }
+      return undefined;
+    },
+  });
+}
+
+function createArrayProxy(
+  schema: ZodArray<ZodTypeAny>,
+  raw: Array<unknown>,
+  path: Array<string | number>,
+): object {
+  const childCache = new Map<number, unknown>();
+  const itemSchema = schema._def.type;
+
+  function resolveIndex(index: number): unknown {
+    if (childCache.has(index)) return childCache.get(index);
+    const childRaw = raw[index];
+    const childPath = [...path, index];
+    const resolved = resolveNode(itemSchema, childRaw, childPath);
+    childCache.set(index, resolved);
+    return resolved;
+  }
+
+  return new Proxy(raw, {
+    get(target, key, receiver) {
+      if (key === TO_PROXY_BRAND) return true;
+      if (key === RAW_DATA) return raw;
+      if (key === SCHEMA) return schema;
+      if (key === "toJSON") return () => raw;
+      if (key === "length") return raw.length;
+
+      if (typeof key === "symbol") return Reflect.get(target, key, receiver);
+
+      const index = Number(key);
+      if (Number.isInteger(index) && index >= 0 && index < raw.length) {
+        return resolveIndex(index);
+      }
+
+      return Reflect.get(target, key, receiver);
+    },
+
+    set() {
+      throw new TypeError("toProxy objects are read-only");
+    },
+
+    deleteProperty() {
+      throw new TypeError("toProxy objects are read-only");
+    },
+
+    defineProperty() {
+      throw new TypeError("toProxy objects are read-only");
+    },
+
+    ownKeys() {
+      const keys: Array<string> = [];
+      for (let i = 0; i < raw.length; i++) {
+        keys.push(String(i));
+      }
+      keys.push("length");
+      return keys;
+    },
+
+    has(_target, key) {
+      if (key === TO_PROXY_BRAND) return true;
+      if (typeof key === "symbol") return false;
+      if (key === "length") return true;
+      const index = Number(key);
+      return Number.isInteger(index) && index >= 0 && index < raw.length;
+    },
+
+    getOwnPropertyDescriptor(target, key) {
+      if (key === "length") {
+        return Object.getOwnPropertyDescriptor(target, "length");
+      }
+      const index = Number(key);
+      if (Number.isInteger(index) && index >= 0 && index < raw.length) {
+        return {
+          configurable: true,
+          enumerable: true,
+          writable: false,
+          value: resolveIndex(index),
+        };
+      }
+      return undefined;
+    },
+  });
+}
+
+function resolveNode(
+  schema: ZodTypeAny,
+  raw: unknown,
+  path: Array<string | number>,
+): unknown {
+  if (schema instanceof ZodOptional) {
+    if (raw === undefined) return undefined;
+    return resolveNode(schema.unwrap(), raw, path);
+  }
+
+  if (schema instanceof ZodNullable) {
+    if (raw === null) return null;
+    return resolveNode(schema.unwrap(), raw, path);
+  }
+
+  if (schema instanceof ZodDefault) {
+    if (raw === undefined) {
+      return resolveNode(
+        schema._def.innerType as ZodTypeAny,
+        schema._def.defaultValue(),
+        path,
+      );
+    }
+    return resolveNode(schema._def.innerType as ZodTypeAny, raw, path);
+  }
+
+  if (schema instanceof ZodCatch) {
+    try {
+      return resolveNode(schema._def.innerType as ZodTypeAny, raw, path);
+    } catch {
+      return schema._def.catchValue({
+        error: new ZodError([]),
+        input: raw,
+      });
+    }
+  }
+
+  const unwrapped = unwrap(schema);
+  if (unwrapped) {
+    return resolveNode(unwrapped, raw, path);
+  }
+
+  const kind = classify(schema);
+
+  if (kind === "leaf") {
+    try {
+      return schema.parse(raw);
+    } catch (err) {
+      throw new ProxyZodError(path, err as import("zod").ZodError);
+    }
+  }
+
+  if (kind === "atomic") {
+    try {
+      return schema.parse(raw);
+    } catch (err) {
+      throw new ProxyZodError(path, err as import("zod").ZodError);
+    }
+  }
+
+  if (raw === null || raw === undefined) {
+    try {
+      schema.parse(raw);
+      return raw;
+    } catch (err) {
+      throw new ProxyZodError(path, err as import("zod").ZodError);
+    }
+  }
+
+  if (typeof raw !== "object") {
+    try {
+      schema.parse(raw);
+      return raw;
+    } catch (err) {
+      throw new ProxyZodError(path, err as import("zod").ZodError);
+    }
+  }
+
+  return wrapDecomposable(schema, raw as object, path);
+}
+
+function wrapDecomposable(
+  schema: ZodTypeAny,
+  raw: object,
+  path: Array<string | number>,
+): object {
+  const cached = getCached(schema, raw);
+  if (cached) return cached;
+
+  let proxy: object;
+
+  if (schema instanceof ZodObject) {
+    proxy = createObjectProxy(
+      schema as ZodObject<Record<string, ZodTypeAny>>,
+      raw as Record<string, unknown>,
+      path,
+    );
+  } else if (schema instanceof ZodArray) {
+    proxy = createArrayProxy(schema, raw as Array<unknown>, path);
+  } else if (schema instanceof ZodTuple) {
+    proxy = createArrayProxy(
+      // Treat tuple similarly to array for now — per-index schema handled later
+      schema as unknown as ZodArray<ZodTypeAny>,
+      raw as Array<unknown>,
+      path,
+    );
+  } else {
+    throw new TypeError(
+      `Unexpected decomposable schema: ${schema.constructor.name}`,
+    );
+  }
+
+  setCached(schema, raw, proxy);
+  return proxy;
+}
+
+export function toProxy<T extends ZodTypeAny>(
+  schema: T,
+  data: unknown,
+): ReadonlyDeep<z.infer<T>> {
+  if (data === null || data === undefined) {
+    throw new TypeError(
+      `toProxy requires an object or array, received ${data === null ? "null" : "undefined"}`,
+    );
+  }
+
+  if (typeof data !== "object") {
+    throw new TypeError(
+      `toProxy requires an object or array, received ${typeof data}`,
+    );
+  }
+
+  let effectiveSchema: ZodTypeAny = schema;
+  let inner = unwrap(effectiveSchema);
+  while (inner) {
+    effectiveSchema = inner;
+    inner = unwrap(effectiveSchema);
+  }
+
+  if (!Object.isExtensible(data)) {
+    return schema.parse(data) as ReadonlyDeep<z.infer<T>>;
+  }
+
+  return wrapDecomposable(effectiveSchema, data as object, []) as ReadonlyDeep<
+    z.infer<T>
+  >;
+}

--- a/packages/zod-to-proxy/src/warnings.ts
+++ b/packages/zod-to-proxy/src/warnings.ts
@@ -1,12 +1,17 @@
 import type { ZodTypeAny } from "zod";
 
-import process from "node:process";
-
 const warned = new WeakSet<ZodTypeAny>();
 
 function isProduction(): boolean {
-  // eslint-disable-next-line dot-notation -- TS noPropertyAccessFromIndexSignature
-  return process.env["NODE_ENV"] === "production";
+  try {
+    // eslint-disable-next-line node/prefer-global/process -- runtime check for browser environments without node:process
+    return (
+      typeof process !== "undefined" &&
+      process.env?.["NODE_ENV"] === "production"
+    ); // eslint-disable-line dot-notation
+  } catch {
+    return false;
+  }
 }
 
 function warnOnce(schema: ZodTypeAny, message: string): void {

--- a/packages/zod-to-proxy/src/warnings.ts
+++ b/packages/zod-to-proxy/src/warnings.ts
@@ -1,0 +1,40 @@
+import type { ZodTypeAny } from "zod";
+
+import process from "node:process";
+
+const warned = new WeakSet<ZodTypeAny>();
+
+function isProduction(): boolean {
+  // eslint-disable-next-line dot-notation -- TS noPropertyAccessFromIndexSignature
+  return process.env["NODE_ENV"] === "production";
+}
+
+function warnOnce(schema: ZodTypeAny, message: string): void {
+  if (warned.has(schema)) return;
+  warned.add(schema);
+  console.warn(`[zod-to-proxy] ${message}`);
+}
+
+export function warnAtomicRoot(schema: ZodTypeAny): void {
+  if (isProduction()) return;
+  warnOnce(
+    schema,
+    "Root schema is atomic — the entire tree will be validated on first access, providing no laziness benefit.",
+  );
+}
+
+export function warnThenInShape(schema: ZodTypeAny): void {
+  if (isProduction()) return;
+  warnOnce(
+    schema,
+    'Schema shape contains a "then" key. Promise.resolve(proxy) will trigger validation of this field due to thenable detection.',
+  );
+}
+
+export function warnFrozenDegradation(schema: ZodTypeAny): void {
+  if (isProduction()) return;
+  warnOnce(
+    schema,
+    "Input data is frozen/sealed — falling back to eager full validation (atomic mode).",
+  );
+}

--- a/packages/zod-to-proxy/src/zodios-plugin.ts
+++ b/packages/zod-to-proxy/src/zodios-plugin.ts
@@ -1,0 +1,90 @@
+import type {
+  AnyZodiosRequestOptions,
+  ZodiosEndpointDefinition,
+  ZodiosEndpointDefinitions,
+  ZodiosPlugin,
+} from "@zodios/core";
+import type { ZodError, ZodTypeAny } from "zod";
+import { zodValidationPlugin } from "@zodios/core";
+
+import { toProxy } from "./to-proxy.js";
+
+export interface ResilientPluginOptions {
+  onError: (
+    error: ZodError,
+    context: {
+      method: string;
+      path: string;
+      data: unknown;
+    },
+  ) => void;
+}
+
+function findEndpoint(
+  api: ZodiosEndpointDefinitions,
+  config: AnyZodiosRequestOptions,
+): ZodiosEndpointDefinition | undefined {
+  return api.find(
+    (e: ZodiosEndpointDefinition) =>
+      e.method === config.method && e.path === config.url,
+  );
+}
+
+function isJsonContentType(
+  headers: Record<string, string> | undefined,
+): boolean {
+  const ct = headers?.["content-type"];
+  if (!ct) return false;
+  return (
+    ct.includes("application/json") || ct.includes("application/vnd.api+json")
+  );
+}
+
+export function resilientPlugin(options: ResilientPluginOptions): ZodiosPlugin {
+  const { onError } = options;
+
+  const original = zodValidationPlugin({
+    validate: true,
+    transform: true,
+    sendDefaults: false,
+  });
+
+  return {
+    name: "zod-validation",
+
+    ...(original.request ? { request: original.request } : {}),
+
+    response: async (api, config, response) => {
+      const endpoint = findEndpoint(
+        api as ZodiosEndpointDefinitions,
+        config as AnyZodiosRequestOptions,
+      );
+      if (!endpoint) return response;
+
+      if (
+        !isJsonContentType(
+          response.headers as Record<string, string> | undefined,
+        )
+      ) {
+        return response;
+      }
+
+      const result = await endpoint.response.safeParseAsync(response.data);
+
+      if (result.success) {
+        response.data = result.data;
+        return response;
+      }
+
+      onError(result.error, {
+        method: endpoint.method,
+        path: endpoint.path,
+        data: response.data,
+      });
+
+      response.data = toProxy(endpoint.response as ZodTypeAny, response.data);
+
+      return response;
+    },
+  };
+}

--- a/packages/zod-to-proxy/src/zodios-plugin.ts
+++ b/packages/zod-to-proxy/src/zodios-plugin.ts
@@ -82,7 +82,9 @@ export function resilientPlugin(options: ResilientPluginOptions): ZodiosPlugin {
         data: response.data,
       });
 
-      response.data = toProxy(endpoint.response as ZodTypeAny, response.data);
+      if (response.data != null && typeof response.data === "object") {
+        response.data = toProxy(endpoint.response as ZodTypeAny, response.data);
+      }
 
       return response;
     },

--- a/packages/zod-to-proxy/src/zodios.ts
+++ b/packages/zod-to-proxy/src/zodios.ts
@@ -1,0 +1,2 @@
+export { resilientPlugin } from "./zodios-plugin.js";
+export type { ResilientPluginOptions } from "./zodios-plugin.js";

--- a/packages/zod-to-proxy/tests/array.test.ts
+++ b/packages/zod-to-proxy/tests/array.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { ProxyZodError, toProxy } from "../src/index.js";
+
+describe("toProxy array behavior", () => {
+  it("accesses valid elements by index", () => {
+    const schema = z.array(z.string());
+    const proxy = toProxy(schema, ["a", "b", "c"]);
+    expect(proxy[0]).toBe("a");
+    expect(proxy[1]).toBe("b");
+    expect(proxy[2]).toBe("c");
+  });
+
+  it("reports correct length", () => {
+    const schema = z.array(z.number());
+    const proxy = toProxy(schema, [1, 2, 3]);
+    expect(proxy.length).toBe(3);
+  });
+
+  it("throws ProxyZodError for invalid element on access", () => {
+    const schema = z.array(z.number());
+    const proxy = toProxy(schema, [1, "bad", 3]);
+    expect(proxy[0]).toBe(1);
+    expect(() => proxy[1]).toThrow(ProxyZodError);
+    expect(proxy[2]).toBe(3);
+  });
+
+  it("proxyZodError has correct numeric path for array elements", () => {
+    const schema = z.array(z.number());
+    const proxy = toProxy(schema, [1, "bad"]);
+    try {
+      void proxy[1];
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect((err as ProxyZodError).path).toEqual([1]);
+    }
+  });
+
+  it("supports nested arrays", () => {
+    const schema = z.array(z.array(z.number()));
+    const proxy = toProxy(schema, [
+      [1, 2],
+      [3, 4],
+    ]);
+    expect(proxy[0][0]).toBe(1);
+    expect(proxy[1][1]).toBe(4);
+  });
+
+  it("nested array error has full path", () => {
+    const schema = z.array(z.array(z.number()));
+    const proxy = toProxy(schema, [[1], ["bad"]]);
+    try {
+      void proxy[1][0];
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect((err as ProxyZodError).path).toEqual([1, 0]);
+    }
+  });
+
+  it("supports iteration with for...of", () => {
+    const schema = z.array(z.number());
+    const proxy = toProxy(schema, [10, 20, 30]);
+    const items: Array<number> = [];
+    for (const item of proxy) {
+      items.push(item);
+    }
+    expect(items).toEqual([10, 20, 30]);
+  });
+
+  it("supports Array.from", () => {
+    const schema = z.array(z.string());
+    const proxy = toProxy(schema, ["a", "b"]);
+    expect(Array.from(proxy)).toEqual(["a", "b"]);
+  });
+
+  it("objects nested in arrays are lazy", () => {
+    const schema = z.array(z.object({ x: z.number(), y: z.string() }));
+    const proxy = toProxy(schema, [
+      { x: 1, y: "ok" },
+      { x: "bad", y: "ok" },
+    ]);
+    expect(proxy[0].y).toBe("ok");
+    expect(proxy[1].y).toBe("ok");
+    expect(() => proxy[1].x).toThrow(ProxyZodError);
+  });
+});

--- a/packages/zod-to-proxy/tests/array.test.ts
+++ b/packages/zod-to-proxy/tests/array.test.ts
@@ -74,6 +74,16 @@ describe("toProxy array behavior", () => {
     expect(Array.from(proxy)).toEqual(["a", "b"]);
   });
 
+  it("does not coerce empty string or whitespace to index 0", () => {
+    const schema = z.array(z.string());
+    const proxy = toProxy(schema, ["a", "b"]);
+    expect((proxy as unknown as Record<string, unknown>)[""]).toBeUndefined();
+    expect((proxy as unknown as Record<string, unknown>)["  "]).toBeUndefined();
+    expect(
+      (proxy as unknown as Record<string, unknown>)["1.0"],
+    ).toBeUndefined();
+  });
+
   it("objects nested in arrays are lazy", () => {
     const schema = z.array(z.object({ x: z.number(), y: z.string() }));
     const proxy = toProxy(schema, [

--- a/packages/zod-to-proxy/tests/atomic.test.ts
+++ b/packages/zod-to-proxy/tests/atomic.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { ProxyZodError, toProxy } from "../src/index.js";
+
+describe("toProxy atomic nodes", () => {
+  describe("zodUnion", () => {
+    it("validates entire union subtree on access", () => {
+      const schema = z.object({
+        value: z.union([z.string(), z.number()]),
+      });
+      const proxy = toProxy(schema, { value: "hello" });
+      expect(proxy.value).toBe("hello");
+    });
+
+    it("throws ProxyZodError for invalid union", () => {
+      const schema = z.object({
+        value: z.union([z.string(), z.number()]),
+      });
+      const proxy = toProxy(schema, { value: true });
+      expect(() => proxy.value).toThrow(ProxyZodError);
+    });
+  });
+
+  describe("zodDiscriminatedUnion", () => {
+    it("validates discriminated union on access", () => {
+      const schema = z.object({
+        event: z.discriminatedUnion("type", [
+          z.object({ type: z.literal("click"), x: z.number() }),
+          z.object({ type: z.literal("scroll"), offset: z.number() }),
+        ]),
+      });
+      const proxy = toProxy(schema, {
+        event: { type: "click", x: 10 },
+      });
+      expect(proxy.event).toEqual({ type: "click", x: 10 });
+    });
+
+    it("throws for invalid discriminated union", () => {
+      const schema = z.object({
+        event: z.discriminatedUnion("type", [
+          z.object({ type: z.literal("click"), x: z.number() }),
+        ]),
+      });
+      const proxy = toProxy(schema, {
+        event: { type: "unknown" },
+      });
+      expect(() => proxy.event).toThrow(ProxyZodError);
+    });
+  });
+
+  describe("zodEffects (transform)", () => {
+    it("applies transform on access", () => {
+      const schema = z.object({
+        value: z.string().transform((s) => s.toUpperCase()),
+      });
+      const proxy = toProxy(schema, { value: "hello" });
+      expect(proxy.value).toBe("HELLO");
+    });
+
+    it("throws ProxyZodError for invalid input to transform", () => {
+      const schema = z.object({
+        value: z.string().transform((s) => s.toUpperCase()),
+      });
+      const proxy = toProxy(schema, { value: 123 });
+      expect(() => proxy.value).toThrow(ProxyZodError);
+    });
+  });
+
+  describe("zodEffects (refine)", () => {
+    it("validates refine on access", () => {
+      const schema = z.object({
+        email: z.string().refine((s) => s.includes("@"), "Must be email"),
+      });
+      const proxy = toProxy(schema, { email: "a@b.com" });
+      expect(proxy.email).toBe("a@b.com");
+    });
+
+    it("throws ProxyZodError for failing refine", () => {
+      const schema = z.object({
+        email: z.string().refine((s) => s.includes("@"), "Must be email"),
+      });
+      const proxy = toProxy(schema, { email: "not-an-email" });
+      expect(() => proxy.email).toThrow(ProxyZodError);
+    });
+  });
+
+  describe("zodRecord", () => {
+    it("validates record on access", () => {
+      const schema = z.object({
+        meta: z.record(z.string(), z.number()),
+      });
+      const proxy = toProxy(schema, { meta: { a: 1, b: 2 } });
+      expect(proxy.meta).toEqual({ a: 1, b: 2 });
+    });
+
+    it("throws ProxyZodError for invalid record values", () => {
+      const schema = z.object({
+        meta: z.record(z.string(), z.number()),
+      });
+      const proxy = toProxy(schema, { meta: { a: "not-number" } });
+      expect(() => proxy.meta).toThrow(ProxyZodError);
+    });
+  });
+
+  describe("zodIntersection", () => {
+    it("validates intersection on access", () => {
+      const schema = z.object({
+        data: z.intersection(
+          z.object({ a: z.string() }),
+          z.object({ b: z.number() }),
+        ),
+      });
+      const proxy = toProxy(schema, { data: { a: "x", b: 1 } });
+      expect(proxy.data).toEqual({ a: "x", b: 1 });
+    });
+
+    it("throws ProxyZodError for invalid intersection", () => {
+      const schema = z.object({
+        data: z.intersection(
+          z.object({ a: z.string() }),
+          z.object({ b: z.number() }),
+        ),
+      });
+      const proxy = toProxy(schema, { data: { a: "x", b: "bad" } });
+      expect(() => proxy.data).toThrow(ProxyZodError);
+    });
+  });
+});

--- a/packages/zod-to-proxy/tests/cache.test.ts
+++ b/packages/zod-to-proxy/tests/cache.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { toProxy } from "../src/index.js";
+
+describe("toProxy caching & identity", () => {
+  it("same (schema, data) returns same proxy instance", () => {
+    const schema = z.object({ x: z.number() });
+    const data = { x: 1 };
+    const a = toProxy(schema, data);
+    const b = toProxy(schema, data);
+    expect(a).toBe(b);
+  });
+
+  it("different data returns different proxy", () => {
+    const schema = z.object({ x: z.number() });
+    const a = toProxy(schema, { x: 1 });
+    const b = toProxy(schema, { x: 2 });
+    expect(a).not.toBe(b);
+  });
+
+  it("child proxy is referentially stable across accesses", () => {
+    const schema = z.object({
+      child: z.object({ val: z.string() }),
+    });
+    const proxy = toProxy(schema, { child: { val: "hi" } });
+    expect(proxy.child).toBe(proxy.child);
+  });
+});

--- a/packages/zod-to-proxy/tests/catch.test.ts
+++ b/packages/zod-to-proxy/tests/catch.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { toProxy } from "../src/index.js";
+
+describe("toProxy ZodCatch behavior", () => {
+  it("returns fallback value when inner validation fails", () => {
+    const schema = z.object({
+      count: z.number().catch(0),
+    });
+    const proxy = toProxy(schema, { count: "not-a-number" });
+    expect(proxy.count).toBe(0);
+  });
+
+  it("returns valid value when inner validation passes", () => {
+    const schema = z.object({
+      count: z.number().catch(0),
+    });
+    const proxy = toProxy(schema, { count: 42 });
+    expect(proxy.count).toBe(42);
+  });
+
+  it("returns fallback for undefined when inner schema is required", () => {
+    const schema = z.object({
+      name: z.string().catch("anonymous"),
+    });
+    const proxy = toProxy(schema, {});
+    expect(proxy.name).toBe("anonymous");
+  });
+
+  it("returns fallback via function", () => {
+    const schema = z.object({
+      items: z.array(z.string()).catch(() => []),
+    });
+    const proxy = toProxy(schema, { items: "not-an-array" });
+    expect(proxy.items).toEqual([]);
+  });
+
+  it("nested catch with object", () => {
+    const schema = z.object({
+      user: z
+        .object({
+          name: z.string(),
+          age: z.number(),
+        })
+        .catch({ name: "unknown", age: 0 }),
+    });
+    const proxy = toProxy(schema, { user: "not-an-object" });
+    expect(proxy.user).toEqual({ name: "unknown", age: 0 });
+  });
+});

--- a/packages/zod-to-proxy/tests/classify.test.ts
+++ b/packages/zod-to-proxy/tests/classify.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { classify } from "../src/classify.js";
+
+describe("schema classification", () => {
+  describe("decomposable", () => {
+    it("classifies ZodObject as decomposable", () => {
+      expect(classify(z.object({ x: z.number() }))).toBe("decomposable");
+    });
+
+    it("classifies ZodArray as decomposable", () => {
+      expect(classify(z.array(z.string()))).toBe("decomposable");
+    });
+
+    it("classifies ZodTuple as decomposable", () => {
+      expect(classify(z.tuple([z.string(), z.number()]))).toBe("decomposable");
+    });
+
+    it("classifies ZodOptional as decomposable", () => {
+      expect(classify(z.string().optional())).toBe("decomposable");
+    });
+
+    it("classifies ZodNullable as decomposable", () => {
+      expect(classify(z.string().nullable())).toBe("decomposable");
+    });
+
+    it("classifies ZodDefault as decomposable", () => {
+      expect(classify(z.string().default("hi"))).toBe("decomposable");
+    });
+
+    it("classifies ZodReadonly as decomposable", () => {
+      expect(classify(z.array(z.string()).readonly())).toBe("decomposable");
+    });
+
+    it("classifies ZodLazy as decomposable", () => {
+      expect(classify(z.lazy(() => z.string()))).toBe("decomposable");
+    });
+
+    it("classifies ZodBranded as decomposable", () => {
+      expect(classify(z.string().brand("UserId"))).toBe("decomposable");
+    });
+
+    it("classifies ZodCatch as decomposable", () => {
+      expect(classify(z.string().catch("fallback"))).toBe("decomposable");
+    });
+
+    it("classifies ZodPipeline as decomposable", () => {
+      expect(classify(z.string().pipe(z.coerce.number()))).toBe("decomposable");
+    });
+  });
+
+  describe("atomic", () => {
+    it("classifies ZodUnion as atomic", () => {
+      expect(classify(z.union([z.string(), z.number()]))).toBe("atomic");
+    });
+
+    it("classifies ZodDiscriminatedUnion as atomic", () => {
+      expect(
+        classify(
+          z.discriminatedUnion("type", [
+            z.object({ type: z.literal("a") }),
+            z.object({ type: z.literal("b") }),
+          ]),
+        ),
+      ).toBe("atomic");
+    });
+
+    it("classifies ZodIntersection as atomic", () => {
+      expect(
+        classify(
+          z.intersection(
+            z.object({ a: z.string() }),
+            z.object({ b: z.number() }),
+          ),
+        ),
+      ).toBe("atomic");
+    });
+
+    it("classifies ZodEffects (refine) as atomic", () => {
+      expect(classify(z.string().refine((s) => s.length > 0))).toBe("atomic");
+    });
+
+    it("classifies ZodEffects (transform) as atomic", () => {
+      expect(classify(z.string().transform((s) => s.length))).toBe("atomic");
+    });
+
+    it("classifies ZodRecord as atomic", () => {
+      expect(classify(z.record(z.string(), z.number()))).toBe("atomic");
+    });
+  });
+
+  describe("leaf", () => {
+    it("classifies ZodString as leaf", () => {
+      expect(classify(z.string())).toBe("leaf");
+    });
+
+    it("classifies ZodNumber as leaf", () => {
+      expect(classify(z.number())).toBe("leaf");
+    });
+
+    it("classifies ZodBoolean as leaf", () => {
+      expect(classify(z.boolean())).toBe("leaf");
+    });
+
+    it("classifies ZodDate as leaf", () => {
+      expect(classify(z.date())).toBe("leaf");
+    });
+
+    it("classifies ZodEnum as leaf", () => {
+      expect(classify(z.enum(["a", "b"]))).toBe("leaf");
+    });
+
+    it("classifies ZodLiteral as leaf", () => {
+      expect(classify(z.literal("hello"))).toBe("leaf");
+    });
+
+    it("classifies ZodUndefined as leaf", () => {
+      expect(classify(z.undefined())).toBe("leaf");
+    });
+
+    it("classifies ZodNull as leaf", () => {
+      expect(classify(z.null())).toBe("leaf");
+    });
+
+    it("classifies ZodAny as leaf", () => {
+      expect(classify(z.any())).toBe("leaf");
+    });
+
+    it("classifies ZodUnknown as leaf", () => {
+      expect(classify(z.unknown())).toBe("leaf");
+    });
+
+    it("classifies ZodNever as leaf", () => {
+      expect(classify(z.never())).toBe("leaf");
+    });
+
+    it("classifies ZodBigInt as leaf", () => {
+      expect(classify(z.bigint())).toBe("leaf");
+    });
+
+    it("classifies ZodNativeEnum as leaf", () => {
+      enum Color {
+        Red = "red",
+        Blue = "blue",
+      }
+      expect(classify(z.nativeEnum(Color))).toBe("leaf");
+    });
+  });
+});

--- a/packages/zod-to-proxy/tests/classify.test.ts
+++ b/packages/zod-to-proxy/tests/classify.test.ts
@@ -44,13 +44,13 @@ describe("schema classification", () => {
     it("classifies ZodCatch as decomposable", () => {
       expect(classify(z.string().catch("fallback"))).toBe("decomposable");
     });
-
-    it("classifies ZodPipeline as decomposable", () => {
-      expect(classify(z.string().pipe(z.coerce.number()))).toBe("decomposable");
-    });
   });
 
   describe("atomic", () => {
+    it("classifies ZodPipeline as atomic", () => {
+      expect(classify(z.string().pipe(z.coerce.number()))).toBe("atomic");
+    });
+
     it("classifies ZodUnion as atomic", () => {
       expect(classify(z.union([z.string(), z.number()]))).toBe("atomic");
     });

--- a/packages/zod-to-proxy/tests/ecosystem.test.ts
+++ b/packages/zod-to-proxy/tests/ecosystem.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { z, ZodObject } from "zod";
+
+describe("ecosystem pinning", () => {
+  it("zodObject has a shape property with own keys", () => {
+    const schema = z.object({ name: z.string(), age: z.number() });
+    expect(schema).toBeInstanceOf(ZodObject);
+    const shape = (schema as z.ZodObject<Record<string, z.ZodTypeAny>>).shape;
+    expect(Object.hasOwn(shape, "name")).toBe(true);
+    expect(Object.hasOwn(shape, "age")).toBe(true);
+    expect(Object.hasOwn(shape, "constructor")).toBe(false);
+  });
+
+  it("zodArray._def.type holds item schema", () => {
+    const schema = z.array(z.string());
+    expect(schema._def.type).toBeInstanceOf(z.ZodString);
+  });
+
+  it("zodOptional.unwrap returns inner schema", () => {
+    const inner = z.string();
+    const schema = inner.optional();
+    expect(schema.unwrap()).toBe(inner);
+  });
+
+  it("zodNullable.unwrap returns inner schema", () => {
+    const inner = z.string();
+    const schema = inner.nullable();
+    expect(schema.unwrap()).toBe(inner);
+  });
+
+  it("zodDefault._def.innerType holds inner schema", () => {
+    const schema = z.string().default("hello");
+    expect(schema._def.innerType).toBeInstanceOf(z.ZodString);
+  });
+
+  it("zodDefault._def.defaultValue is a function", () => {
+    const schema = z.number().default(42);
+    expect(typeof schema._def.defaultValue).toBe("function");
+    expect(schema._def.defaultValue()).toBe(42);
+  });
+
+  it("zodEffects wraps transform/refine schemas", () => {
+    const schema = z.string().transform((s) => s.length);
+    expect(schema).toBeInstanceOf(z.ZodEffects);
+  });
+
+  it("zodPipeline._def.out holds output schema", () => {
+    const schema = z.string().pipe(z.coerce.number());
+    expect(schema._def.out).toBeInstanceOf(z.ZodNumber);
+  });
+});

--- a/packages/zod-to-proxy/tests/enumeration.test.ts
+++ b/packages/zod-to-proxy/tests/enumeration.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { toProxy } from "../src/index.js";
+
+describe("toProxy enumeration traps", () => {
+  it("object.keys returns schema shape keys only", () => {
+    const schema = z.object({ a: z.string(), b: z.number() });
+    const proxy = toProxy(schema, { a: "x", b: 1, extra: true });
+    expect(Object.keys(proxy)).toEqual(["a", "b"]);
+  });
+
+  it("'key in proxy' returns true for shape keys", () => {
+    const schema = z.object({ a: z.string() });
+    const proxy = toProxy(schema, { a: "x" });
+    expect("a" in proxy).toBe(true);
+  });
+
+  it("'key in proxy' returns false for non-shape keys", () => {
+    const schema = z.object({ a: z.string() });
+    const proxy = toProxy(schema, { a: "x", b: 1 });
+    expect("b" in proxy).toBe(false);
+  });
+
+  it("spread operator produces only shape keys", () => {
+    const schema = z.object({ a: z.string(), b: z.number() });
+    const proxy = toProxy(schema, { a: "x", b: 1, extra: true });
+    const spread = { ...proxy };
+    expect(Object.keys(spread)).toEqual(["a", "b"]);
+  });
+
+  it("for...in iterates only shape keys", () => {
+    const schema = z.object({ a: z.string(), b: z.number() });
+    const proxy = toProxy(schema, { a: "x", b: 1, extra: true });
+    const keys: Array<string> = [];
+    for (const key in proxy) {
+      keys.push(key);
+    }
+    expect(keys).toEqual(["a", "b"]);
+  });
+
+  describe("array enumeration", () => {
+    it("object.keys returns indices as strings", () => {
+      const schema = z.array(z.string());
+      const proxy = toProxy(schema, ["a", "b", "c"]);
+      expect(Object.keys(proxy)).toEqual(["0", "1", "2"]);
+    });
+
+    it("spread produces array elements", () => {
+      const schema = z.array(z.number());
+      const proxy = toProxy(schema, [1, 2, 3]);
+      const spread = [...proxy];
+      expect(spread).toEqual([1, 2, 3]);
+    });
+  });
+});

--- a/packages/zod-to-proxy/tests/error.test.ts
+++ b/packages/zod-to-proxy/tests/error.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { ProxyZodError, toProxy } from "../src/index.js";
+
+describe("proxyZodError details", () => {
+  it("has correct name", () => {
+    const schema = z.object({ x: z.number() });
+    const proxy = toProxy(schema, { x: "bad" });
+    try {
+      void proxy.x;
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect((err as ProxyZodError).name).toBe("ProxyZodError");
+    }
+  });
+
+  it("path contains full nested access path", () => {
+    const schema = z.object({
+      a: z.object({
+        b: z.object({
+          c: z.number(),
+        }),
+      }),
+    });
+    const proxy = toProxy(schema, { a: { b: { c: "bad" } } });
+    try {
+      void proxy.a.b.c;
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect((err as ProxyZodError).path).toEqual(["a", "b", "c"]);
+    }
+  });
+
+  it("path includes numeric indices for arrays", () => {
+    const schema = z.object({
+      items: z.array(z.object({ value: z.number() })),
+    });
+    const proxy = toProxy(schema, {
+      items: [{ value: 1 }, { value: "bad" }],
+    });
+    try {
+      void proxy.items[1].value;
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect((err as ProxyZodError).path).toEqual(["items", 1, "value"]);
+    }
+  });
+
+  it("zodError contains the zod validation error", () => {
+    const schema = z.object({ age: z.number() });
+    const proxy = toProxy(schema, { age: "bad" });
+    try {
+      void proxy.age;
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      const pze = err as ProxyZodError;
+      expect(pze.zodError).toBeInstanceOf(z.ZodError);
+      expect(pze.zodError.issues.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("cause is the same as zodError", () => {
+    const schema = z.object({ age: z.number() });
+    const proxy = toProxy(schema, { age: "bad" });
+    try {
+      void proxy.age;
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      const pze = err as ProxyZodError;
+      expect(pze.cause).toBe(pze.zodError);
+    }
+  });
+
+  it("flatIssues returns flattened issues", () => {
+    const schema = z.object({ age: z.number() });
+    const proxy = toProxy(schema, { age: "bad" });
+    try {
+      void proxy.age;
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      const pze = err as ProxyZodError;
+      const issues = pze.flatIssues();
+      expect(issues.length).toBeGreaterThan(0);
+      expect(issues[0]!.code).toBe("invalid_type");
+    }
+  });
+
+  it("message includes path", () => {
+    const schema = z.object({
+      user: z.object({ name: z.number() }),
+    });
+    const proxy = toProxy(schema, { user: { name: "bad" } });
+    try {
+      void proxy.user.name;
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect((err as ProxyZodError).message).toContain("user.name");
+    }
+  });
+
+  describe("isProxyZodError", () => {
+    it("returns true for ProxyZodError instances", () => {
+      const schema = z.object({ x: z.number() });
+      const proxy = toProxy(schema, { x: "bad" });
+      try {
+        void proxy.x;
+        expect.unreachable("should have thrown");
+      } catch (err) {
+        expect(ProxyZodError.isProxyZodError(err)).toBe(true);
+      }
+    });
+
+    it("returns false for regular errors", () => {
+      expect(ProxyZodError.isProxyZodError(new Error("nope"))).toBe(false);
+    });
+
+    it("returns false for non-error values", () => {
+      expect(ProxyZodError.isProxyZodError(null)).toBe(false);
+      expect(ProxyZodError.isProxyZodError("string")).toBe(false);
+      expect(ProxyZodError.isProxyZodError(42)).toBe(false);
+    });
+
+    it("detects via Symbol.for brand (cross-realm simulation)", () => {
+      const fake = {
+        [Symbol.for("ProxyZodError")]: true,
+      };
+      expect(ProxyZodError.isProxyZodError(fake)).toBe(true);
+    });
+  });
+});

--- a/packages/zod-to-proxy/tests/escape-hatches.test.ts
+++ b/packages/zod-to-proxy/tests/escape-hatches.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { getRaw, isToProxy, materialize, toProxy } from "../src/index.js";
+
+describe("escape hatches", () => {
+  describe("getRaw", () => {
+    it("returns raw data from a proxy", () => {
+      const data = { name: "Alice", age: 30 };
+      const schema = z.object({ name: z.string(), age: z.number() });
+      const proxy = toProxy(schema, data);
+      expect(getRaw(proxy)).toBe(data);
+    });
+
+    it("returns input as-is for non-proxy values", () => {
+      expect(getRaw("hello")).toBe("hello");
+      expect(getRaw(42)).toBe(42);
+      expect(getRaw(null)).toBe(null);
+      expect(getRaw(undefined)).toBe(undefined);
+    });
+
+    it("returns raw from nested child proxy", () => {
+      const childData = { x: 1 };
+      const data = { child: childData };
+      const schema = z.object({ child: z.object({ x: z.number() }) });
+      const proxy = toProxy(schema, data);
+      expect(getRaw(proxy.child)).toBe(childData);
+    });
+  });
+
+  describe("materialize", () => {
+    it("fully validates and returns parsed data from proxy", () => {
+      const schema = z.object({ name: z.string(), count: z.number() });
+      const proxy = toProxy(schema, { name: "Alice", count: 5 });
+      const result = materialize(proxy);
+      expect(result).toEqual({ name: "Alice", count: 5 });
+    });
+
+    it("throws ZodError for invalid data", () => {
+      const schema = z.object({ name: z.string(), count: z.number() });
+      const proxy = toProxy(schema, { name: "Alice", count: "bad" });
+      expect(() => materialize(proxy)).toThrow();
+    });
+
+    it("returns input as-is for non-proxy values", () => {
+      expect(materialize("hello")).toBe("hello");
+      expect(materialize(42)).toBe(42);
+      expect(materialize(null)).toBe(null);
+    });
+  });
+
+  describe("isToProxy", () => {
+    it("returns true for a proxy", () => {
+      const schema = z.object({ x: z.number() });
+      const proxy = toProxy(schema, { x: 1 });
+      expect(isToProxy(proxy)).toBe(true);
+    });
+
+    it("returns false for plain objects", () => {
+      expect(isToProxy({ x: 1 })).toBe(false);
+    });
+
+    it("returns false for primitives", () => {
+      expect(isToProxy("hello")).toBe(false);
+      expect(isToProxy(42)).toBe(false);
+      expect(isToProxy(null)).toBe(false);
+      expect(isToProxy(undefined)).toBe(false);
+    });
+
+    it("returns true for array proxy", () => {
+      const schema = z.array(z.number());
+      const proxy = toProxy(schema, [1, 2]);
+      expect(isToProxy(proxy)).toBe(true);
+    });
+  });
+});

--- a/packages/zod-to-proxy/tests/integration.test.ts
+++ b/packages/zod-to-proxy/tests/integration.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+  getRaw,
+  isToProxy,
+  materialize,
+  ProxyZodError,
+  toProxy,
+} from "../src/index.js";
+
+describe("integration: real-world zodios-like response", () => {
+  const UserSchema = z.object({
+    id: z.number(),
+    name: z.string(),
+    email: z.string(),
+    address: z.object({
+      street: z.string(),
+      city: z.string(),
+      zipcode: z.string(),
+      geo: z.object({
+        lat: z.string(),
+        lng: z.string(),
+      }),
+    }),
+    company: z.object({
+      name: z.string(),
+      catchPhrase: z.string(),
+    }),
+    website: z.string(),
+  });
+
+  const rawUser = {
+    id: 1,
+    name: "Alice Wang",
+    email: "alice@example.com",
+    address: {
+      street: "123 Main St",
+      city: "Taipei",
+      zipcode: "10601",
+      geo: {
+        lat: "25.0330",
+        lng: "121.5654",
+      },
+    },
+    company: {
+      name: "Acme Corp",
+      catchPhrase: "Building the future",
+    },
+    website: "example.com",
+    extraFieldFromApi: "should be ignored",
+  };
+
+  it("creates proxy without throwing despite extra field", () => {
+    expect(() => toProxy(UserSchema, rawUser)).not.toThrow();
+  });
+
+  it("accesses valid top-level fields", () => {
+    const user = toProxy(UserSchema, rawUser);
+    expect(user.id).toBe(1);
+    expect(user.name).toBe("Alice Wang");
+    expect(user.email).toBe("alice@example.com");
+  });
+
+  it("accesses valid nested fields lazily", () => {
+    const user = toProxy(UserSchema, rawUser);
+    expect(user.address.city).toBe("Taipei");
+    expect(user.address.geo.lat).toBe("25.0330");
+    expect(user.company.name).toBe("Acme Corp");
+  });
+
+  it("strips extra fields not in schema", () => {
+    const user = toProxy(UserSchema, rawUser);
+    expect(
+      (user as unknown as Record<string, unknown>).extraFieldFromApi,
+    ).toBeUndefined();
+    expect(Object.keys(user)).not.toContain("extraFieldFromApi");
+  });
+
+  it("serializes to raw JSON without triggering validation", () => {
+    const user = toProxy(UserSchema, rawUser);
+    const json = JSON.parse(JSON.stringify(user));
+    expect(json.name).toBe("Alice Wang");
+    expect(json.extraFieldFromApi).toBe("should be ignored");
+  });
+
+  it("getRaw returns original data", () => {
+    const user = toProxy(UserSchema, rawUser);
+    expect(getRaw(user)).toBe(rawUser);
+  });
+
+  it("isToProxy identifies proxy", () => {
+    const user = toProxy(UserSchema, rawUser);
+    expect(isToProxy(user)).toBe(true);
+    expect(isToProxy(rawUser)).toBe(false);
+  });
+
+  it("materialize runs full validation", () => {
+    const user = toProxy(UserSchema, rawUser);
+    const result = materialize(user) as z.infer<typeof UserSchema>;
+    expect(result.name).toBe("Alice Wang");
+    expect(result.address.city).toBe("Taipei");
+  });
+
+  describe("with partially broken response", () => {
+    const brokenRawUser = {
+      ...rawUser,
+      address: {
+        ...rawUser.address,
+        geo: {
+          lat: 123,
+          lng: null,
+        },
+      },
+    };
+
+    it("accesses valid paths without errors", () => {
+      const user = toProxy(UserSchema, brokenRawUser);
+      expect(user.name).toBe("Alice Wang");
+      expect(user.address.city).toBe("Taipei");
+      expect(user.company.catchPhrase).toBe("Building the future");
+    });
+
+    it("throws ProxyZodError only when broken path is accessed", () => {
+      const user = toProxy(UserSchema, brokenRawUser);
+      expect(() => user.address.geo.lat).toThrow(ProxyZodError);
+
+      try {
+        void user.address.geo.lat;
+      } catch (err) {
+        const pze = err as ProxyZodError;
+        expect(pze.path).toEqual(["address", "geo", "lat"]);
+        expect(pze.zodError.issues[0]!.code).toBe("invalid_type");
+      }
+    });
+
+    it("sibling of broken path is still accessible", () => {
+      const user = toProxy(UserSchema, brokenRawUser);
+      expect(user.address.street).toBe("123 Main St");
+    });
+  });
+
+  describe("list endpoint", () => {
+    const UsersSchema = z.array(UserSchema);
+
+    it("wraps array of users lazily", () => {
+      const users = toProxy(UsersSchema, [rawUser, rawUser]);
+      expect(users.length).toBe(2);
+      expect(users[0].name).toBe("Alice Wang");
+      expect(users[1].address.city).toBe("Taipei");
+    });
+
+    it("broken item does not affect other items", () => {
+      const brokenUser = { ...rawUser, name: 42 };
+      const users = toProxy(UsersSchema, [rawUser, brokenUser]);
+      expect(users[0].name).toBe("Alice Wang");
+      expect(() => users[1].name).toThrow(ProxyZodError);
+    });
+  });
+});

--- a/packages/zod-to-proxy/tests/object.test.ts
+++ b/packages/zod-to-proxy/tests/object.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { ProxyZodError, toProxy } from "../src/index.js";
+
+describe("toProxy object lazy access", () => {
+  it("returns valid field value on access", () => {
+    const schema = z.object({ name: z.string(), age: z.number() });
+    const proxy = toProxy(schema, { name: "Alice", age: 30 });
+    expect(proxy.name).toBe("Alice");
+    expect(proxy.age).toBe(30);
+  });
+
+  it("throws ProxyZodError when accessing invalid field", () => {
+    const schema = z.object({ name: z.string(), age: z.number() });
+    const proxy = toProxy(schema, { name: "Alice", age: "not-a-number" });
+
+    expect(proxy.name).toBe("Alice");
+    expect(() => proxy.age).toThrow(ProxyZodError);
+  });
+
+  it("proxyZodError contains correct path for top-level field", () => {
+    const schema = z.object({ age: z.number() });
+    const proxy = toProxy(schema, { age: "bad" });
+
+    try {
+      void proxy.age;
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(ProxyZodError.isProxyZodError(err)).toBe(true);
+      expect((err as ProxyZodError).path).toEqual(["age"]);
+    }
+  });
+
+  it("returns undefined for non-shape own keys (strips extra fields)", () => {
+    const schema = z.object({ name: z.string() });
+    const proxy = toProxy(schema, { name: "Alice", extra: "stuff" });
+    expect((proxy as Record<string, unknown>).extra).toBeUndefined();
+  });
+
+  it("lazily resolves nested objects", () => {
+    const schema = z.object({
+      user: z.object({
+        name: z.string(),
+        address: z.object({ city: z.string() }),
+      }),
+    });
+    const proxy = toProxy(schema, {
+      user: { name: "Alice", address: { city: "Taipei" } },
+    });
+    expect(proxy.user.name).toBe("Alice");
+    expect(proxy.user.address.city).toBe("Taipei");
+  });
+
+  it("throws ProxyZodError with nested path for deep invalid field", () => {
+    const schema = z.object({
+      user: z.object({
+        profile: z.object({
+          age: z.number(),
+        }),
+      }),
+    });
+    const proxy = toProxy(schema, {
+      user: { profile: { age: "bad" } },
+    });
+
+    try {
+      void proxy.user.profile.age;
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(ProxyZodError.isProxyZodError(err)).toBe(true);
+      expect((err as ProxyZodError).path).toEqual(["user", "profile", "age"]);
+    }
+  });
+
+  it("does not throw when invalid sibling is never accessed", () => {
+    const schema = z.object({
+      good: z.string(),
+      bad: z.number(),
+    });
+    const proxy = toProxy(schema, { good: "ok", bad: "not-a-number" });
+    expect(proxy.good).toBe("ok");
+  });
+
+  it("caches resolved child values (same reference on repeated access)", () => {
+    const schema = z.object({
+      nested: z.object({ x: z.number() }),
+    });
+    const proxy = toProxy(schema, { nested: { x: 1 } });
+    const first = proxy.nested;
+    const second = proxy.nested;
+    expect(first).toBe(second);
+  });
+});

--- a/packages/zod-to-proxy/tests/prototype.test.ts
+++ b/packages/zod-to-proxy/tests/prototype.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { toProxy } from "../src/index.js";
+
+describe("toProxy prototype & special keys", () => {
+  it("toString returns [object Object] via prototype passthrough", () => {
+    const schema = z.object({ x: z.number() });
+    const proxy = toProxy(schema, { x: 1 });
+    expect(proxy.toString()).toBe("[object Object]");
+  });
+
+  it("valueOf returns the proxy itself", () => {
+    const schema = z.object({ x: z.number() });
+    const proxy = toProxy(schema, { x: 1 });
+    expect(proxy.valueOf()).toBe(proxy);
+  });
+
+  it("constructor is not confused with Object.prototype.constructor", () => {
+    const schema = z.object({ x: z.number() });
+    const proxy = toProxy(schema, { x: 1 });
+    expect("constructor" in proxy).toBe(false);
+  });
+
+  it("does not include constructor in Object.keys", () => {
+    const schema = z.object({ x: z.number() });
+    const proxy = toProxy(schema, { x: 1 });
+    expect(Object.keys(proxy)).toEqual(["x"]);
+  });
+
+  it("schema with constructor field works correctly", () => {
+    const schema = z.object({ constructor: z.string() });
+    const proxy = toProxy(schema, { constructor: "MyClass" });
+    expect(proxy.constructor).toBe("MyClass");
+    expect("constructor" in proxy).toBe(true);
+  });
+
+  it("toJSON returns raw data for JSON.stringify", () => {
+    const schema = z.object({ name: z.string(), bad: z.number() });
+    const proxy = toProxy(schema, { name: "Alice", bad: "not-a-number" });
+    expect(JSON.stringify(proxy)).toBe(
+      JSON.stringify({ name: "Alice", bad: "not-a-number" }),
+    );
+  });
+
+  it("symbol.toPrimitive is passed through", () => {
+    const schema = z.object({ x: z.number() });
+    const proxy = toProxy(schema, { x: 1 });
+    expect(Symbol.toPrimitive in proxy).toBe(false);
+  });
+});

--- a/packages/zod-to-proxy/tests/readonly.test.ts
+++ b/packages/zod-to-proxy/tests/readonly.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { toProxy } from "../src/index.js";
+
+describe("toProxy read-only enforcement", () => {
+  it("setting a property throws TypeError", () => {
+    const schema = z.object({ x: z.number() });
+    const proxy = toProxy(schema, { x: 1 }) as Record<string, unknown>;
+    expect(() => {
+      proxy.x = 2;
+    }).toThrow(TypeError);
+  });
+
+  it("deleting a property throws TypeError", () => {
+    const schema = z.object({ x: z.number() });
+    const proxy = toProxy(schema, { x: 1 }) as Record<string, unknown>;
+    expect(() => {
+      delete proxy.x;
+    }).toThrow(TypeError);
+  });
+
+  it("defineProperty throws TypeError", () => {
+    const schema = z.object({ x: z.number() });
+    const proxy = toProxy(schema, { x: 1 });
+    expect(() => {
+      Object.defineProperty(proxy, "y", { value: 2 });
+    }).toThrow(TypeError);
+  });
+
+  it("array proxy rejects set", () => {
+    const schema = z.array(z.number());
+    const proxy = toProxy(schema, [1, 2, 3]) as Array<unknown>;
+    expect(() => {
+      proxy[0] = 99;
+    }).toThrow(TypeError);
+  });
+});

--- a/packages/zod-to-proxy/tests/real-world.test.ts
+++ b/packages/zod-to-proxy/tests/real-world.test.ts
@@ -1,0 +1,362 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { ProxyZodError, toProxy } from "../src/index.js";
+
+// -- DateValue: class instantiated via z.transform --
+
+class DateValue {
+  readonly year: number;
+  readonly month: number;
+  readonly day: number;
+
+  constructor(year: number, month: number, day: number) {
+    this.year = year;
+    this.month = month;
+    this.day = day;
+  }
+
+  toString(): string {
+    return `${this.year}-${String(this.month).padStart(2, "0")}-${String(this.day).padStart(2, "0")}`;
+  }
+}
+
+const DateStringSchema = z
+  .string()
+  .date()
+  .transform((value) => {
+    const [year, month, day] = value.split("-").map(Number);
+    return new DateValue(year!, month!, day!);
+  });
+
+// -- tolerantEnum: wraps an enum so unknown values produce a fallback
+//    instead of throwing --
+
+const unexpectedSymbol = Symbol("unexpected");
+
+function tolerantEnum<T extends string>(schema: z.ZodType<T>) {
+  return z.string().transform((raw) => {
+    const result = schema.safeParse(raw);
+    if (result.success) {
+      return { expected: true as const, value: result.data };
+    }
+    return {
+      expected: false as const,
+      value: unexpectedSymbol,
+      raw,
+    };
+  });
+}
+
+// -- test schemas --
+
+const MetricSchema = z.object({
+  date: DateStringSchema,
+  value: z.number().int(),
+  label: z.string().nullable(),
+});
+
+const ContactSchema = z.object({
+  id: z.number().int(),
+  name: z.string(),
+  email: z.string(),
+  birthday: z.string().transform((s) => {
+    if (!s || s === "9999-12-31") return null;
+    const d = new Date(s);
+    if (Number.isNaN(d.getTime())) return null;
+    return new DateValue(d.getFullYear(), d.getMonth() + 1, d.getDate());
+  }),
+  role: tolerantEnum(z.enum(["admin", "editor", "viewer"])),
+});
+
+const RoutingRuleSchema = z.discriminatedUnion("strategy", [
+  z.object({ strategy: z.literal("direct"), agentId: z.number().int() }),
+  z.object({ strategy: z.literal("round-robin") }),
+  z.object({ strategy: z.literal("group"), groupId: z.number().int() }),
+]);
+
+const AttachmentSchema = z.union([
+  z.object({
+    filename: z.string(),
+    sizeBytes: z.number().int(),
+  }),
+  z.object({
+    durationMs: z.number(),
+  }),
+]);
+
+const NoteSchema = z.object({
+  id: z.number().int(),
+  body: z.string(),
+  author: z.enum(["human", "system", "bot"]),
+  attachment: AttachmentSchema.nullable().catch(null),
+  createdAt: z.string(),
+});
+
+const OrderStatusSchema = z.enum(["paid", "pending", "refunded"]);
+
+// -- tests --
+
+describe("real-world patterns", () => {
+  describe("class-instantiating transform", () => {
+    it("transforms date string into class instance on access", () => {
+      const schema = z.object({ metric: MetricSchema });
+      const proxy = toProxy(schema, {
+        metric: { date: "2026-06-12", value: 42, label: "daily" },
+      });
+      const date = proxy.metric.date;
+      expect(date).toBeInstanceOf(DateValue);
+      expect(date.toString()).toBe("2026-06-12");
+      expect(date.year).toBe(2026);
+    });
+
+    it("throws ProxyZodError for invalid date string", () => {
+      const schema = z.object({ metric: MetricSchema });
+      const proxy = toProxy(schema, {
+        metric: { date: "not-a-date", value: 1, label: null },
+      });
+      expect(proxy.metric.value).toBe(1);
+      expect(() => proxy.metric.date).toThrow(ProxyZodError);
+    });
+
+    it("does not validate date transform when only label is accessed", () => {
+      const schema = z.object({ metric: MetricSchema });
+      const proxy = toProxy(schema, {
+        metric: { date: "bad", value: 1, label: "test" },
+      });
+      expect(proxy.metric.label).toBe("test");
+    });
+  });
+
+  describe("nullable date transform with sentinel", () => {
+    it("transforms valid date into class instance", () => {
+      const proxy = toProxy(ContactSchema, {
+        id: 1,
+        name: "Alice",
+        email: "a@b.com",
+        birthday: "1990-05-15",
+        role: "admin",
+      });
+      const birthday = proxy.birthday;
+      expect(birthday).toBeInstanceOf(DateValue);
+      expect(birthday!.toString()).toBe("1990-05-15");
+    });
+
+    it("returns null for sentinel value 9999-12-31", () => {
+      const proxy = toProxy(ContactSchema, {
+        id: 1,
+        name: "Bob",
+        email: "b@c.com",
+        birthday: "9999-12-31",
+        role: "admin",
+      });
+      expect(proxy.birthday).toBeNull();
+    });
+
+    it("returns null for invalid date string", () => {
+      const proxy = toProxy(ContactSchema, {
+        id: 1,
+        name: "Eve",
+        email: "e@f.com",
+        birthday: "not-a-date",
+        role: "admin",
+      });
+      expect(proxy.birthday).toBeNull();
+    });
+  });
+
+  describe("tolerant enum (unknown values don't throw)", () => {
+    it("returns expected: true for known value", () => {
+      const proxy = toProxy(ContactSchema, {
+        id: 1,
+        name: "Alice",
+        email: "a@b.com",
+        birthday: "1990-01-01",
+        role: "admin",
+      });
+      expect(proxy.role).toEqual({ expected: true, value: "admin" });
+    });
+
+    it("returns expected: false with raw for unknown value", () => {
+      const proxy = toProxy(ContactSchema, {
+        id: 1,
+        name: "Alice",
+        email: "a@b.com",
+        birthday: "1990-01-01",
+        role: "superadmin",
+      });
+      const role = proxy.role;
+      expect(role.expected).toBe(false);
+      expect("raw" in role && role.raw).toBe("superadmin");
+      expect("value" in role && role.value).toBe(unexpectedSymbol);
+    });
+
+    it("does not evaluate enum when only name is read", () => {
+      const proxy = toProxy(ContactSchema, {
+        id: 1,
+        name: "Alice",
+        email: "a@b.com",
+        birthday: "1990-01-01",
+        role: "superadmin",
+      });
+      expect(proxy.name).toBe("Alice");
+    });
+  });
+
+  describe("tolerant enum with order status", () => {
+    const OrderSchema = z.object({
+      orderId: z.string(),
+      status: tolerantEnum(OrderStatusSchema),
+      total: z.number(),
+    });
+
+    it("handles known status", () => {
+      const proxy = toProxy(OrderSchema, {
+        orderId: "ORD-001",
+        status: "paid",
+        total: 100,
+      });
+      expect(proxy.status).toEqual({ expected: true, value: "paid" });
+    });
+
+    it("handles unknown status from newer API version", () => {
+      const proxy = toProxy(OrderSchema, {
+        orderId: "ORD-002",
+        status: "partially_refunded",
+        total: 50,
+      });
+      expect(proxy.status.expected).toBe(false);
+      expect(proxy.total).toBe(50);
+    });
+  });
+
+  describe("discriminated union", () => {
+    const ConfigSchema = z.object({
+      name: z.string(),
+      routing: RoutingRuleSchema,
+    });
+
+    it("resolves direct variant", () => {
+      const proxy = toProxy(ConfigSchema, {
+        name: "VIP config",
+        routing: { strategy: "direct", agentId: 42 },
+      });
+      expect(proxy.routing).toEqual({ strategy: "direct", agentId: 42 });
+    });
+
+    it("resolves round-robin variant", () => {
+      const proxy = toProxy(ConfigSchema, {
+        name: "Default",
+        routing: { strategy: "round-robin" },
+      });
+      expect(proxy.routing).toEqual({ strategy: "round-robin" });
+    });
+
+    it("throws for unknown discriminator value", () => {
+      const proxy = toProxy(ConfigSchema, {
+        name: "Bad config",
+        routing: { strategy: "random" },
+      });
+      expect(proxy.name).toBe("Bad config");
+      expect(() => proxy.routing).toThrow(ProxyZodError);
+    });
+  });
+
+  describe("union with catch fallback", () => {
+    it("resolves file attachment variant", () => {
+      const proxy = toProxy(NoteSchema, {
+        id: 1,
+        body: "see attachment",
+        author: "human",
+        attachment: { filename: "doc.pdf", sizeBytes: 1024 },
+        createdAt: "2026-06-12T00:00:00Z",
+      });
+      expect(proxy.attachment).toEqual({
+        filename: "doc.pdf",
+        sizeBytes: 1024,
+      });
+    });
+
+    it("resolves audio attachment variant", () => {
+      const proxy = toProxy(NoteSchema, {
+        id: 2,
+        body: "voice note",
+        author: "human",
+        attachment: { durationMs: 3200 },
+        createdAt: "2026-06-12T00:00:00Z",
+      });
+      expect(proxy.attachment).toEqual({ durationMs: 3200 });
+    });
+
+    it("falls back to null for unrecognized attachment shape", () => {
+      const proxy = toProxy(NoteSchema, {
+        id: 3,
+        body: "sticker",
+        author: "bot",
+        attachment: { stickerId: "abc", packId: "xyz" },
+        createdAt: "2026-06-12T00:00:00Z",
+      });
+      expect(proxy.attachment).toBeNull();
+    });
+
+    it("unrecognized attachment does not affect other fields", () => {
+      const proxy = toProxy(NoteSchema, {
+        id: 4,
+        body: "hello",
+        author: "human",
+        attachment: { broken: true },
+        createdAt: "2026-06-12T00:00:00Z",
+      });
+      expect(proxy.body).toBe("hello");
+      expect(proxy.author).toBe("human");
+      expect(proxy.attachment).toBeNull();
+    });
+  });
+
+  describe("array of notes (list endpoint)", () => {
+    const NotesSchema = z.array(NoteSchema);
+
+    it("broken attachment in one item does not affect others", () => {
+      const proxy = toProxy(NotesSchema, [
+        {
+          id: 1,
+          body: "hi",
+          author: "human",
+          attachment: null,
+          createdAt: "2026-06-12T00:00:00Z",
+        },
+        {
+          id: 2,
+          body: "file",
+          author: "system",
+          attachment: { broken: "shape" },
+          createdAt: "2026-06-12T00:00:00Z",
+        },
+      ]);
+      expect(proxy[0].body).toBe("hi");
+      expect(proxy[1].body).toBe("file");
+      expect(proxy[1].attachment).toBeNull();
+    });
+  });
+
+  describe("metrics array with class transform", () => {
+    const DashboardSchema = z.object({
+      metrics: z.array(MetricSchema),
+    });
+
+    it("lazily transforms each date independently", () => {
+      const proxy = toProxy(DashboardSchema, {
+        metrics: [
+          { date: "2026-06-10", value: 100, label: null },
+          { date: "bad-date", value: 200, label: null },
+          { date: "2026-06-12", value: 300, label: "today" },
+        ],
+      });
+      expect(proxy.metrics[0].date.toString()).toBe("2026-06-10");
+      expect(proxy.metrics[2].date.toString()).toBe("2026-06-12");
+      expect(proxy.metrics[2].label).toBe("today");
+      expect(() => proxy.metrics[1].date).toThrow(ProxyZodError);
+      expect(proxy.metrics[1].value).toBe(200);
+    });
+  });
+});

--- a/packages/zod-to-proxy/tests/root.test.ts
+++ b/packages/zod-to-proxy/tests/root.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { toProxy } from "../src/index.js";
+
+describe("toProxy root behavior", () => {
+  it("returns a proxy for object schema with valid data", () => {
+    const schema = z.object({ name: z.string() });
+    const result = toProxy(schema, { name: "Alice" });
+    expect(result).toBeDefined();
+    expect(typeof result).toBe("object");
+  });
+
+  it("returns a proxy for object schema with partially invalid data", () => {
+    const schema = z.object({ name: z.string(), age: z.number() });
+    const result = toProxy(schema, { name: "Alice", age: "not-a-number" });
+    expect(result).toBeDefined();
+    expect(typeof result).toBe("object");
+  });
+
+  it("throws TypeError for null input", () => {
+    const schema = z.object({ name: z.string() });
+    expect(() => toProxy(schema, null)).toThrow(TypeError);
+  });
+
+  it("throws TypeError for undefined input", () => {
+    const schema = z.object({ name: z.string() });
+    expect(() => toProxy(schema, undefined)).toThrow(TypeError);
+  });
+
+  it("throws TypeError for primitive string input", () => {
+    const schema = z.object({ name: z.string() });
+    expect(() => toProxy(schema, "hello")).toThrow(TypeError);
+  });
+
+  it("throws TypeError for primitive number input", () => {
+    const schema = z.object({ name: z.string() });
+    expect(() => toProxy(schema, 42)).toThrow(TypeError);
+  });
+
+  it("throws TypeError for primitive boolean input", () => {
+    const schema = z.object({ name: z.string() });
+    expect(() => toProxy(schema, true)).toThrow(TypeError);
+  });
+
+  it("accepts array input with array schema", () => {
+    const schema = z.array(z.string());
+    const result = toProxy(schema, ["a", "b"]);
+    expect(result).toBeDefined();
+  });
+
+  it("does not eagerly validate — invalid fields do not throw on creation", () => {
+    const schema = z.object({
+      valid: z.string(),
+      invalid: z.number(),
+      nested: z.object({ deep: z.boolean() }),
+    });
+    expect(() =>
+      toProxy(schema, {
+        valid: "ok",
+        invalid: "not-a-number",
+        nested: { deep: "not-a-boolean" },
+      }),
+    ).not.toThrow();
+  });
+});

--- a/packages/zod-to-proxy/tests/tuple.test.ts
+++ b/packages/zod-to-proxy/tests/tuple.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { ProxyZodError, toProxy } from "../src/index.js";
+
+describe("toProxy ZodTuple behavior", () => {
+  it("validates each element against its position schema", () => {
+    const schema = z.tuple([z.string(), z.number(), z.boolean()]);
+    const proxy = toProxy(schema, ["hello", 42, true]);
+    expect(proxy[0]).toBe("hello");
+    expect(proxy[1]).toBe(42);
+    expect(proxy[2]).toBe(true);
+  });
+
+  it("throws ProxyZodError for wrong type at position", () => {
+    const schema = z.tuple([z.string(), z.number()]);
+    const proxy = toProxy(schema, ["hello", "not-a-number"]);
+    expect(proxy[0]).toBe("hello");
+    expect(() => proxy[1]).toThrow(ProxyZodError);
+  });
+
+  it("reports correct path with numeric index", () => {
+    const schema = z.tuple([z.string(), z.number()]);
+    const proxy = toProxy(schema, ["hello", "bad"]);
+    try {
+      void proxy[1];
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect((err as ProxyZodError).path).toEqual([1]);
+    }
+  });
+
+  it("returns correct length", () => {
+    const schema = z.tuple([z.string(), z.number()]);
+    const proxy = toProxy(schema, ["hello", 42]);
+    expect(proxy.length).toBe(2);
+  });
+
+  it("supports nested objects in tuple elements", () => {
+    const schema = z.tuple([
+      z.object({ name: z.string() }),
+      z.object({ value: z.number() }),
+    ]);
+    const proxy = toProxy(schema, [{ name: "Alice" }, { value: 42 }]);
+    expect(proxy[0].name).toBe("Alice");
+    expect(proxy[1].value).toBe(42);
+  });
+
+  it("supports rest elements", () => {
+    const schema = z.tuple([z.string()]).rest(z.number());
+    const proxy = toProxy(schema, ["hello", 1, 2, 3]);
+    expect(proxy[0]).toBe("hello");
+    expect(proxy[1]).toBe(1);
+    expect(proxy[2]).toBe(2);
+    expect(proxy[3]).toBe(3);
+  });
+
+  it("throws for invalid rest element", () => {
+    const schema = z.tuple([z.string()]).rest(z.number());
+    const proxy = toProxy(schema, ["hello", "bad"]);
+    expect(proxy[0]).toBe("hello");
+    expect(() => proxy[1]).toThrow(ProxyZodError);
+  });
+});

--- a/packages/zod-to-proxy/tests/types.test.ts
+++ b/packages/zod-to-proxy/tests/types.test.ts
@@ -1,0 +1,78 @@
+import { describe, expectTypeOf, it } from "vitest";
+import { z } from "zod";
+
+import {
+  getRaw,
+  isToProxy,
+  materialize,
+  ProxyZodError,
+  toProxy,
+} from "../src/index.js";
+
+describe("type tests", () => {
+  it("toProxy returns ReadonlyDeep<z.infer<T>>", () => {
+    const schema = z.object({
+      name: z.string(),
+      nested: z.object({ value: z.number() }),
+    });
+    const result = toProxy(schema, { name: "test", nested: { value: 1 } });
+    expectTypeOf(result.name).toBeString();
+    expectTypeOf(result.nested.value).toBeNumber();
+  });
+
+  it("toProxy result is readonly (nested)", () => {
+    const schema = z.object({
+      items: z.array(z.object({ x: z.number() })),
+    });
+    const result = toProxy(schema, { items: [{ x: 1 }] });
+    expectTypeOf(result.items).toBeObject();
+
+    type Result = typeof result;
+    type ItemsProp = Result["items"];
+    expectTypeOf<ItemsProp>().toEqualTypeOf<
+      ReadonlyArray<Readonly<{ x: number }>>
+    >();
+  });
+
+  it("proxyZodError.isProxyZodError narrows type", () => {
+    const err: unknown = new Error("test");
+    if (ProxyZodError.isProxyZodError(err)) {
+      expectTypeOf(err).toEqualTypeOf<ProxyZodError>();
+      expectTypeOf(err.path).toEqualTypeOf<Array<string | number>>();
+    }
+  });
+
+  it("getRaw returns unknown", () => {
+    const schema = z.object({ x: z.number() });
+    const proxy = toProxy(schema, { x: 1 });
+    expectTypeOf(getRaw(proxy)).toBeUnknown();
+  });
+
+  it("materialize returns unknown", () => {
+    const schema = z.object({ x: z.number() });
+    const proxy = toProxy(schema, { x: 1 });
+    expectTypeOf(materialize(proxy)).toBeUnknown();
+  });
+
+  it("isToProxy returns boolean", () => {
+    expectTypeOf(isToProxy({})).toBeBoolean();
+  });
+
+  it("handles optional fields", () => {
+    const schema = z.object({ name: z.string().optional() });
+    const result = toProxy(schema, {});
+    expectTypeOf(result.name).toEqualTypeOf<string | undefined>();
+  });
+
+  it("handles nullable fields", () => {
+    const schema = z.object({ name: z.string().nullable() });
+    const result = toProxy(schema, { name: null });
+    expectTypeOf(result.name).toEqualTypeOf<string | null>();
+  });
+
+  it("handles array schema", () => {
+    const schema = z.array(z.number());
+    const result = toProxy(schema, [1, 2, 3]);
+    expectTypeOf(result).toEqualTypeOf<ReadonlyArray<number>>();
+  });
+});

--- a/packages/zod-to-proxy/tests/warnings.test.ts
+++ b/packages/zod-to-proxy/tests/warnings.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import { toProxy } from "../src/index.js";
+
+describe("dev warnings", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("warns when root schema is atomic (union)", () => {
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const schema = z.union([
+      z.object({ type: z.literal("a") }),
+      z.object({ type: z.literal("b") }),
+    ]);
+    toProxy(schema, { type: "a" });
+    expect(spy).toHaveBeenCalledOnce();
+    expect(spy.mock.calls[0]![0]).toContain("atomic");
+  });
+
+  it("warns when root schema is atomic (transform)", () => {
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const schema = z
+      .object({ x: z.number() })
+      .transform((obj) => ({ ...obj, doubled: obj.x * 2 }));
+    toProxy(schema, { x: 5 });
+    expect(spy).toHaveBeenCalledOnce();
+    expect(spy.mock.calls[0]![0]).toContain("atomic");
+  });
+
+  it('warns when shape contains "then" key', () => {
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const schema = z.object({
+      then: z.string(),
+      value: z.number(),
+    });
+    toProxy(schema, { then: "next", value: 1 });
+    expect(spy).toHaveBeenCalledOnce();
+    expect(spy.mock.calls[0]![0]).toContain("then");
+  });
+
+  it("warns when input data is frozen", () => {
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const schema = z.object({ x: z.number() });
+    const data = Object.freeze({ x: 1 });
+    toProxy(schema, data);
+    expect(spy).toHaveBeenCalledOnce();
+    expect(spy.mock.calls[0]![0]).toContain("frozen");
+  });
+
+  it("warns only once per schema (deduplicated)", () => {
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const schema = z.object({ then: z.string() });
+    toProxy(schema, { then: "a" });
+    toProxy(schema, { then: "b" });
+    expect(spy).toHaveBeenCalledOnce();
+  });
+
+  it("suppresses warnings in production mode", () => {
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    try {
+      const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const schema = z.object({ then: z.string() });
+      toProxy(schema, { then: "a" });
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      process.env.NODE_ENV = originalEnv;
+    }
+  });
+});

--- a/packages/zod-to-proxy/tests/wrappers.test.ts
+++ b/packages/zod-to-proxy/tests/wrappers.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { ProxyZodError, toProxy } from "../src/index.js";
+
+describe("toProxy wrapper semantics", () => {
+  describe("zodOptional", () => {
+    it("returns undefined for missing optional field", () => {
+      const schema = z.object({ name: z.string().optional() });
+      const proxy = toProxy(schema, {});
+      expect(proxy.name).toBeUndefined();
+    });
+
+    it("returns value for present optional field", () => {
+      const schema = z.object({ name: z.string().optional() });
+      const proxy = toProxy(schema, { name: "Alice" });
+      expect(proxy.name).toBe("Alice");
+    });
+
+    it("throws for null on optional (not nullable)", () => {
+      const schema = z.object({ name: z.string().optional() });
+      const proxy = toProxy(schema, { name: null });
+      expect(() => proxy.name).toThrow(ProxyZodError);
+    });
+  });
+
+  describe("zodNullable", () => {
+    it("returns null for null nullable field", () => {
+      const schema = z.object({ name: z.string().nullable() });
+      const proxy = toProxy(schema, { name: null });
+      expect(proxy.name).toBeNull();
+    });
+
+    it("returns value for present nullable field", () => {
+      const schema = z.object({ name: z.string().nullable() });
+      const proxy = toProxy(schema, { name: "Alice" });
+      expect(proxy.name).toBe("Alice");
+    });
+
+    it("throws for undefined on nullable (not optional)", () => {
+      const schema = z.object({ name: z.string().nullable() });
+      const proxy = toProxy(schema, {});
+      expect(() => proxy.name).toThrow(ProxyZodError);
+    });
+  });
+
+  describe("zodDefault", () => {
+    it("substitutes default for undefined", () => {
+      const schema = z.object({ count: z.number().default(0) });
+      const proxy = toProxy(schema, {});
+      expect(proxy.count).toBe(0);
+    });
+
+    it("does not substitute default for explicit value", () => {
+      const schema = z.object({ count: z.number().default(0) });
+      const proxy = toProxy(schema, { count: 5 });
+      expect(proxy.count).toBe(5);
+    });
+
+    it("throws for null on default (not nullable)", () => {
+      const schema = z.object({ count: z.number().default(0) });
+      const proxy = toProxy(schema, { count: null });
+      expect(() => proxy.count).toThrow(ProxyZodError);
+    });
+  });
+
+  describe("zodReadonly", () => {
+    it("unwraps readonly and resolves inner schema", () => {
+      const schema = z.object({
+        items: z.array(z.string()).readonly(),
+      });
+      const proxy = toProxy(schema, { items: ["a", "b"] });
+      expect(proxy.items[0]).toBe("a");
+    });
+  });
+
+  describe("nested wrappers", () => {
+    it("optional + nullable: null is valid", () => {
+      const schema = z.object({ x: z.string().optional().nullable() });
+      const proxy = toProxy(schema, { x: null });
+      expect(proxy.x).toBeNull();
+    });
+
+    it("optional + nullable: undefined is valid", () => {
+      const schema = z.object({ x: z.string().optional().nullable() });
+      const proxy = toProxy(schema, {});
+      expect(proxy.x).toBeUndefined();
+    });
+
+    it("nullable + optional: null is valid", () => {
+      const schema = z.object({ x: z.string().nullable().optional() });
+      const proxy = toProxy(schema, { x: null });
+      expect(proxy.x).toBeNull();
+    });
+
+    it("nullable + optional: undefined is valid", () => {
+      const schema = z.object({ x: z.string().nullable().optional() });
+      const proxy = toProxy(schema, {});
+      expect(proxy.x).toBeUndefined();
+    });
+  });
+});

--- a/packages/zod-to-proxy/tests/zodios-plugin.test.ts
+++ b/packages/zod-to-proxy/tests/zodios-plugin.test.ts
@@ -147,6 +147,30 @@ describe("resilientPlugin", () => {
     });
   });
 
+  describe("response: null/primitive data fallback", () => {
+    it("does not crash when response.data is null", async () => {
+      const onError = vi.fn();
+      const plugin = resilientPlugin({ onError });
+      const response = makeResponse(null);
+
+      const result = await plugin.response!(api, makeConfig(), response);
+
+      expect(onError).toHaveBeenCalledOnce();
+      expect(result.data).toBeNull();
+    });
+
+    it("does not crash when response.data is a primitive", async () => {
+      const onError = vi.fn();
+      const plugin = resilientPlugin({ onError });
+      const response = makeResponse("just a string");
+
+      const result = await plugin.response!(api, makeConfig(), response);
+
+      expect(onError).toHaveBeenCalledOnce();
+      expect(result.data).toBe("just a string");
+    });
+  });
+
   describe("response: non-json content-type passthrough", () => {
     it("passes through text/plain responses without validation", async () => {
       const onError = vi.fn();

--- a/packages/zod-to-proxy/tests/zodios-plugin.test.ts
+++ b/packages/zod-to-proxy/tests/zodios-plugin.test.ts
@@ -1,0 +1,302 @@
+import type {
+  AnyZodiosRequestOptions,
+  ZodiosEndpointDefinitions,
+} from "@zodios/core";
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import { isToProxy, ProxyZodError } from "../src/index.js";
+import { resilientPlugin } from "../src/zodios-plugin.js";
+
+const UserSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  email: z.string(),
+});
+
+const api: ZodiosEndpointDefinitions = [
+  {
+    method: "get",
+    path: "/users/:id",
+    response: UserSchema,
+    alias: "getUser",
+    description: "Get user by ID",
+    parameters: [],
+    errors: [],
+  },
+];
+
+function makeConfig(
+  overrides: Partial<AnyZodiosRequestOptions> = {},
+): AnyZodiosRequestOptions {
+  return {
+    method: "get",
+    url: "/users/:id",
+    ...overrides,
+  } as AnyZodiosRequestOptions;
+}
+
+function makeResponse(
+  data: unknown,
+  headers: Record<string, string> = { "content-type": "application/json" },
+) {
+  return { data, headers } as Parameters<
+    NonNullable<ReturnType<typeof resilientPlugin>["response"]>
+  >[2];
+}
+
+describe("resilientPlugin", () => {
+  describe("plugin metadata", () => {
+    it("uses 'zod-validation' name to replace built-in", () => {
+      const plugin = resilientPlugin({ onError: vi.fn() });
+      expect(plugin.name).toBe("zod-validation");
+    });
+
+    it("has a response hook", () => {
+      const plugin = resilientPlugin({ onError: vi.fn() });
+      expect(plugin.response).toBeTypeOf("function");
+    });
+
+    it("delegates request hook from original zodValidationPlugin", () => {
+      const plugin = resilientPlugin({ onError: vi.fn() });
+      expect(plugin.request).toBeTypeOf("function");
+    });
+  });
+
+  describe("response: valid data", () => {
+    it("returns parsed data when validation succeeds", async () => {
+      const onError = vi.fn();
+      const plugin = resilientPlugin({ onError });
+      const response = makeResponse({ id: 1, name: "Alice", email: "a@b.com" });
+
+      const result = await plugin.response!(api, makeConfig(), response);
+
+      expect(result.data).toEqual({ id: 1, name: "Alice", email: "a@b.com" });
+      expect(onError).not.toHaveBeenCalled();
+      expect(isToProxy(result.data)).toBe(false);
+    });
+
+    it("strips extra fields on successful parse", async () => {
+      const plugin = resilientPlugin({ onError: vi.fn() });
+      const response = makeResponse({
+        id: 1,
+        name: "Alice",
+        email: "a@b.com",
+        extraField: "ignored",
+      });
+
+      const result = await plugin.response!(api, makeConfig(), response);
+
+      expect(result.data).toEqual({ id: 1, name: "Alice", email: "a@b.com" });
+      expect(
+        (result.data as Record<string, unknown>).extraField,
+      ).toBeUndefined();
+    });
+  });
+
+  describe("response: invalid data → toProxy fallback", () => {
+    it("calls onError and returns toProxy wrapper on validation failure", async () => {
+      const onError = vi.fn();
+      const plugin = resilientPlugin({ onError });
+      const rawData = { id: 1, name: 42, email: "a@b.com" };
+      const response = makeResponse(rawData);
+
+      const result = await plugin.response!(api, makeConfig(), response);
+
+      expect(onError).toHaveBeenCalledOnce();
+      expect(isToProxy(result.data)).toBe(true);
+    });
+
+    it("passes ZodError to onError with correct context", async () => {
+      const onError = vi.fn();
+      const plugin = resilientPlugin({ onError });
+      const rawData = { id: "not-a-number", name: "Alice", email: "a@b.com" };
+      const response = makeResponse(rawData);
+
+      await plugin.response!(api, makeConfig(), response);
+
+      const [error, context] = onError.mock.calls[0]!;
+      expect(error).toBeInstanceOf(z.ZodError);
+      expect(error.issues[0].code).toBe("invalid_type");
+      expect(context).toEqual({
+        method: "get",
+        path: "/users/:id",
+        data: rawData,
+      });
+    });
+
+    it("toProxy fallback still serves valid fields", async () => {
+      const plugin = resilientPlugin({ onError: vi.fn() });
+      const response = makeResponse({ id: 1, name: 42, email: "a@b.com" });
+
+      const result = await plugin.response!(api, makeConfig(), response);
+      const data = result.data as z.infer<typeof UserSchema>;
+
+      expect(data.id).toBe(1);
+      expect(data.email).toBe("a@b.com");
+    });
+
+    it("toProxy fallback throws ProxyZodError on broken field access", async () => {
+      const plugin = resilientPlugin({ onError: vi.fn() });
+      const response = makeResponse({ id: 1, name: 42, email: "a@b.com" });
+
+      const result = await plugin.response!(api, makeConfig(), response);
+      const data = result.data as z.infer<typeof UserSchema>;
+
+      expect(() => data.name).toThrow(ProxyZodError);
+    });
+  });
+
+  describe("response: non-json content-type passthrough", () => {
+    it("passes through text/plain responses without validation", async () => {
+      const onError = vi.fn();
+      const plugin = resilientPlugin({ onError });
+      const response = makeResponse("raw text", {
+        "content-type": "text/plain",
+      });
+
+      const result = await plugin.response!(api, makeConfig(), response);
+
+      expect(result.data).toBe("raw text");
+      expect(onError).not.toHaveBeenCalled();
+    });
+
+    it("passes through responses with no content-type header", async () => {
+      const onError = vi.fn();
+      const plugin = resilientPlugin({ onError });
+      const response = makeResponse("something", {});
+
+      const result = await plugin.response!(api, makeConfig(), response);
+
+      expect(result.data).toBe("something");
+      expect(onError).not.toHaveBeenCalled();
+    });
+
+    it("validates application/vnd.api+json responses", async () => {
+      const onError = vi.fn();
+      const plugin = resilientPlugin({ onError });
+      const response = makeResponse(
+        { id: 1, name: "Alice", email: "a@b.com" },
+        { "content-type": "application/vnd.api+json" },
+      );
+
+      const result = await plugin.response!(api, makeConfig(), response);
+
+      expect(result.data).toEqual({ id: 1, name: "Alice", email: "a@b.com" });
+      expect(onError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("response: unknown endpoint passthrough", () => {
+    it("passes through response when endpoint is not found in api", async () => {
+      const onError = vi.fn();
+      const plugin = resilientPlugin({ onError });
+      const config = makeConfig({ method: "post", url: "/unknown" });
+      const response = makeResponse({ anything: true });
+
+      const result = await plugin.response!(api, config, response);
+
+      expect(result.data).toEqual({ anything: true });
+      expect(onError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("response: transform schemas", () => {
+    const TransformApi: ZodiosEndpointDefinitions = [
+      {
+        method: "get",
+        path: "/date",
+        response: z.object({
+          createdAt: z.string().transform((s) => new Date(s)),
+        }),
+        alias: "getDate",
+        description: "Get date",
+        parameters: [],
+        errors: [],
+      },
+    ];
+
+    it("applies transforms on successful parse", async () => {
+      const plugin = resilientPlugin({ onError: vi.fn() });
+      const response = makeResponse({ createdAt: "2026-06-12T00:00:00Z" });
+      const config = makeConfig({ method: "get", url: "/date" });
+
+      const result = await plugin.response!(TransformApi, config, response);
+
+      expect(result.data).toEqual({
+        createdAt: new Date("2026-06-12T00:00:00Z"),
+      });
+    });
+
+    it("falls back to toProxy when transform input is invalid", async () => {
+      const onError = vi.fn();
+      const plugin = resilientPlugin({ onError });
+      const response = makeResponse({ createdAt: 12345 });
+      const config = makeConfig({ method: "get", url: "/date" });
+
+      const result = await plugin.response!(TransformApi, config, response);
+
+      expect(onError).toHaveBeenCalledOnce();
+      expect(isToProxy(result.data)).toBe(true);
+    });
+  });
+
+  describe("multiple endpoints", () => {
+    const multiApi: ZodiosEndpointDefinitions = [
+      {
+        method: "get",
+        path: "/users/:id",
+        response: UserSchema,
+        alias: "getUser",
+        description: "Get user",
+        parameters: [],
+        errors: [],
+      },
+      {
+        method: "get",
+        path: "/posts/:id",
+        response: z.object({
+          id: z.number(),
+          title: z.string(),
+          body: z.string(),
+        }),
+        alias: "getPost",
+        description: "Get post",
+        parameters: [],
+        errors: [],
+      },
+    ];
+
+    it("matches the correct endpoint schema", async () => {
+      const plugin = resilientPlugin({ onError: vi.fn() });
+
+      const userResponse = makeResponse({
+        id: 1,
+        name: "Alice",
+        email: "a@b.com",
+      });
+      const userResult = await plugin.response!(
+        multiApi,
+        makeConfig({ method: "get", url: "/users/:id" }),
+        userResponse,
+      );
+      expect(userResult.data).toEqual({
+        id: 1,
+        name: "Alice",
+        email: "a@b.com",
+      });
+
+      const postResponse = makeResponse({
+        id: 1,
+        title: "Hello",
+        body: "World",
+      });
+      const postResult = await plugin.response!(
+        multiApi,
+        makeConfig({ method: "get", url: "/posts/:id" }),
+        postResponse,
+      );
+      expect(postResult.data).toEqual({ id: 1, title: "Hello", body: "World" });
+    });
+  });
+});

--- a/packages/zod-to-proxy/tsconfig.lib.json
+++ b/packages/zod-to-proxy/tsconfig.lib.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.lib.tsbuildinfo"
+  },
+  "extends": ["@repo/tsconfig/tsconfig.app"],
+  "include": ["./src/**/*"]
+}

--- a/packages/zod-to-proxy/tsconfig.node.json
+++ b/packages/zod-to-proxy/tsconfig.node.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo"
+  },
+  "extends": ["@repo/tsconfig/tsconfig.node"],
+  "include": ["*"]
+}

--- a/packages/zod-to-proxy/tsdown.config.ts
+++ b/packages/zod-to-proxy/tsdown.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  dts: true,
+  tsconfig: "tsconfig.lib.json",
+  copy: [
+    { from: "../../README.md", to: "README.md" },
+    { from: "../../LICENSE", to: "LICENSE" },
+  ],
+});

--- a/packages/zod-to-proxy/tsdown.config.ts
+++ b/packages/zod-to-proxy/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: ["src/index.ts", "src/zodios.ts"],
   dts: true,
   tsconfig: "tsconfig.lib.json",
   copy: [

--- a/packages/zod-to-proxy/vitest.config.ts
+++ b/packages/zod-to-proxy/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -468,6 +468,9 @@ importers:
 
   packages/zod-to-proxy:
     dependencies:
+      '@zodios/core':
+        specifier: ^10.9.0
+        version: 10.9.6(axios@1.9.0)(zod@3.25.51)
       type-fest:
         specifier: 'catalog:'
         version: 4.41.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -466,6 +466,25 @@ importers:
 
   packages/tsconfig: {}
 
+  packages/zod-to-proxy:
+    dependencies:
+      type-fest:
+        specifier: 'catalog:'
+        version: 4.41.0
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.15.29
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.12.6(typescript@5.8.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.8.3
+      zod:
+        specifier: 'catalog:'
+        version: 3.25.51
+
 packages:
 
   '@adobe/css-tools@4.4.3':

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,8 @@
     { "path": "./tsconfig.node.json" },
     { "path": "./packages/core/tsconfig.lib.json" },
     { "path": "./packages/core/tsconfig.node.json" },
+    { "path": "./packages/zod-to-proxy/tsconfig.lib.json" },
+    { "path": "./packages/zod-to-proxy/tsconfig.node.json" },
     { "path": "./packages/examples/tsconfig.app.json" },
     { "path": "./packages/examples/tsconfig.node.json" }
   ]


### PR DESCRIPTION
## Summary

New package `@crescendolab/zod-to-proxy` — wraps raw data in a JS Proxy that defers Zod validation to property-access time. Fields that are never accessed are never validated, making API responses tolerant of backend schema drift in unused fields.

- **`toProxy(schema, data)`** — returns a `ReadonlyDeep` proxy; accessing a valid field returns its value, accessing an invalid field throws `ProxyZodError` with full path
- **`ProxyZodError`** — custom error with `.path`, `.zodError`, `.flatIssues()`, cross-realm `isProxyZodError()` guard
- **`getRaw` / `materialize` / `isToProxy`** — escape hatches (lenient: non-proxy input passes through)
- Schema nodes classified as **decomposable** (lazy children), **atomic** (eager on touch: union/transform/refine/record), or **leaf** (terminal)
- Global `WeakMap` cache for referential stability across calls
- Dev warnings for atomic root, `then`-in-shape, frozen input degradation
- `toJSON` special-cased to return raw data (avoids triggering full validation via `JSON.stringify`)

Design document: `docs/plans/2026-06-11-zod-to-proxy-design.md`

## Test plan

- [x] 173 tests across 18 files (root, object, array, tuple, catch, wrappers, atomic, classification, warnings, prototype, enumeration, cache, readonly, escape hatches, error details, ecosystem pinning, types, integration)
- [x] TypeScript clean (`tsc --noEmit`)
- [x] ESLint clean
- [x] Build succeeds (`tsdown`)
- [x] Two review passes with fixes:
  - ZodTuple per-position schema validation via `createIndexedProxy`
  - ZodCatch only catches validation errors, re-throws others
  - ES Proxy invariant compliance (non-configurable target properties)
  - Array index coercion fix (regex validation instead of `Number()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)